### PR TITLE
feat: add inject-head-attrs post-build script for static head metadata

### DIFF
--- a/__tests__/inject-head-attrs.test.js
+++ b/__tests__/inject-head-attrs.test.js
@@ -1,0 +1,313 @@
+/**
+ * Tests for the core injection logic of scripts/inject-head-attrs.js.
+ *
+ * The build script processes HTML files on disk; here we exercise the same
+ * logic against in-memory document objects so the tests run in Jest's jsdom
+ * environment without file I/O or subprocess overhead.
+ *
+ * See scripts/inject-head-attrs.js for the full implementation.
+ */
+
+// ── Core helpers (mirrors scripts/inject-head-attrs.js) ──────────────────────
+
+function extractLiteral(expr) {
+  if (!expr) return null;
+  const m = expr.trim().match(/^(['"])([\s\S]*)\1$/);
+  return m ? m[2] : null;
+}
+
+function applyHeadAttrs(document) {
+  const head = document.head;
+
+  function setTitle(val) {
+    let el = head.querySelector("title");
+    if (!el) { el = document.createElement("title"); head.appendChild(el); }
+    el.textContent = val;
+  }
+  function setDescription(val) {
+    let el = head.querySelector('meta[name="description"]');
+    if (!el) { el = document.createElement("meta"); el.name = "description"; head.appendChild(el); }
+    el.content = val;
+  }
+  function setCanonical(val) {
+    let el = head.querySelector('link[rel="canonical"]');
+    if (!el) { el = document.createElement("link"); el.rel = "canonical"; head.appendChild(el); }
+    el.href = val;
+  }
+  function setJsonLd(json) {
+    let el = head.querySelector('script[type="application/ld+json"][data-nojs]');
+    if (!el) {
+      el = document.createElement("script");
+      el.type = "application/ld+json";
+      el.setAttribute("data-nojs", "");
+      head.appendChild(el);
+    }
+    el.textContent = json;
+  }
+
+  // Body directives — exclude template[route] elements (handled separately below)
+  for (const el of document.querySelectorAll("[page-title]:not(template[route])")) {
+    const val = extractLiteral(el.getAttribute("page-title"));
+    if (val != null) setTitle(val);
+  }
+  for (const el of document.querySelectorAll("[page-description]:not(template[route])")) {
+    const val = extractLiteral(el.getAttribute("page-description"));
+    if (val != null) setDescription(val);
+  }
+  for (const el of document.querySelectorAll("[page-canonical]:not(template[route])")) {
+    const val = extractLiteral(el.getAttribute("page-canonical"));
+    if (val != null) setCanonical(val);
+  }
+  for (const el of document.querySelectorAll("[page-jsonld]:not(template[route])")) {
+    const json = (el.textContent || el.innerHTML).trim();
+    if (json) setJsonLd(json);
+  }
+
+  // Route template head attributes (M8 — PR #34)
+  const routeTemplates = [...document.querySelectorAll("template[route]")];
+  const defaultTpl =
+    routeTemplates.find((t) => t.getAttribute("route") === "/") ||
+    routeTemplates[0];
+
+  for (const tpl of routeTemplates) {
+    const isSpaDefault = tpl === defaultTpl;
+    const isOnlyTemplate = routeTemplates.length === 1;
+    if (!isSpaDefault && !isOnlyTemplate) continue;
+
+    const titleVal = extractLiteral(tpl.getAttribute("page-title"));
+    if (titleVal != null && !document.querySelector("[page-title]:not(template[route])")) setTitle(titleVal);
+
+    const descVal = extractLiteral(tpl.getAttribute("page-description"));
+    if (descVal != null && !document.querySelector("[page-description]:not(template[route])")) setDescription(descVal);
+
+    const canonicalVal = extractLiteral(tpl.getAttribute("page-canonical"));
+    if (canonicalVal != null && !document.querySelector("[page-canonical]:not(template[route])")) setCanonical(canonicalVal);
+
+    const jsonldAttr = tpl.getAttribute("page-jsonld");
+    if (jsonldAttr && !document.querySelector("[page-jsonld]:not(template[route])")) setJsonLd(jsonldAttr);
+  }
+}
+
+// ── Test helpers ──────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  document.head.innerHTML = "";
+  document.body.innerHTML = "";
+});
+
+// ── extractLiteral ────────────────────────────────────────────────────────────
+
+describe("extractLiteral", () => {
+  test("extracts single-quoted string", () => {
+    expect(extractLiteral("'About Us | Store'")).toBe("About Us | Store");
+  });
+  test("extracts double-quoted string", () => {
+    expect(extractLiteral('"About Us | Store"')).toBe("About Us | Store");
+  });
+  test("returns null for dynamic expression", () => {
+    expect(extractLiteral("product.name + ' | Store'")).toBeNull();
+  });
+  test("returns null for variable reference", () => {
+    expect(extractLiteral("product.description")).toBeNull();
+  });
+  test("returns null for empty string", () => {
+    expect(extractLiteral("")).toBeNull();
+  });
+  test("returns null for null", () => {
+    expect(extractLiteral(null)).toBeNull();
+  });
+});
+
+// ── page-title ────────────────────────────────────────────────────────────────
+
+describe("inject-head-attrs — page-title", () => {
+  test("injects <title> from a static string literal", () => {
+    document.body.innerHTML = `<div hidden page-title="'About Us | Store'"></div>`;
+    applyHeadAttrs(document);
+    expect(document.querySelector("title").textContent).toBe("About Us | Store");
+  });
+
+  test("accepts double-quoted literal", () => {
+    document.body.innerHTML = `<div hidden page-title='"My Site"'></div>`;
+    applyHeadAttrs(document);
+    expect(document.querySelector("title").textContent).toBe("My Site");
+  });
+
+  test("updates existing <title> in place without duplicating", () => {
+    const existing = document.createElement("title");
+    existing.textContent = "Old Title";
+    document.head.appendChild(existing);
+    document.body.innerHTML = `<div hidden page-title="'New Title'"></div>`;
+    applyHeadAttrs(document);
+    expect(document.querySelectorAll("title").length).toBe(1);
+    expect(document.querySelector("title").textContent).toBe("New Title");
+  });
+
+  test("skips dynamic expression — title unchanged", () => {
+    const existing = document.createElement("title");
+    existing.textContent = "Default";
+    document.head.appendChild(existing);
+    document.body.innerHTML = `<div hidden page-title="product.name + ' | Store'"></div>`;
+    applyHeadAttrs(document);
+    expect(document.querySelector("title").textContent).toBe("Default");
+  });
+});
+
+// ── page-description ──────────────────────────────────────────────────────────
+
+describe("inject-head-attrs — page-description", () => {
+  test("creates <meta name=description> from a static literal", () => {
+    document.body.innerHTML = `<div hidden page-description="'Best sneakers online'"></div>`;
+    applyHeadAttrs(document);
+    const meta = document.querySelector('meta[name="description"]');
+    expect(meta).not.toBeNull();
+    expect(meta.content).toBe("Best sneakers online");
+  });
+
+  test("updates existing description meta without duplicating", () => {
+    const existing = document.createElement("meta");
+    existing.name = "description";
+    existing.content = "Old";
+    document.head.appendChild(existing);
+    document.body.innerHTML = `<div hidden page-description="'New Description'"></div>`;
+    applyHeadAttrs(document);
+    const metas = document.querySelectorAll('meta[name="description"]');
+    expect(metas.length).toBe(1);
+    expect(metas[0].content).toBe("New Description");
+  });
+
+  test("skips dynamic expression", () => {
+    document.body.innerHTML = `<div hidden page-description="product.description"></div>`;
+    applyHeadAttrs(document);
+    expect(document.querySelector('meta[name="description"]')).toBeNull();
+  });
+});
+
+// ── page-canonical ────────────────────────────────────────────────────────────
+
+describe("inject-head-attrs — page-canonical", () => {
+  test("creates <link rel=canonical> from a static literal", () => {
+    document.body.innerHTML = `<div hidden page-canonical="'/about'"></div>`;
+    applyHeadAttrs(document);
+    const link = document.querySelector('link[rel="canonical"]');
+    expect(link).not.toBeNull();
+    expect(link.getAttribute("href")).toContain("/about");
+  });
+
+  test("updates existing canonical without duplicating", () => {
+    const existing = document.createElement("link");
+    existing.rel = "canonical";
+    existing.href = "/old";
+    document.head.appendChild(existing);
+    document.body.innerHTML = `<div hidden page-canonical="'/new'"></div>`;
+    applyHeadAttrs(document);
+    expect(document.querySelectorAll('link[rel="canonical"]').length).toBe(1);
+    expect(document.querySelector('link[rel="canonical"]').getAttribute("href")).toContain("/new");
+  });
+
+  test("skips dynamic expression", () => {
+    document.body.innerHTML = `<div hidden page-canonical="'/products/' + product.slug"></div>`;
+    applyHeadAttrs(document);
+    expect(document.querySelector('link[rel="canonical"]')).toBeNull();
+  });
+});
+
+// ── page-jsonld ───────────────────────────────────────────────────────────────
+
+describe("inject-head-attrs — page-jsonld", () => {
+  test("injects <script type=application/ld+json data-nojs>", () => {
+    document.body.innerHTML = `<div hidden page-jsonld>{"@type":"WebPage","name":"About"}</div>`;
+    applyHeadAttrs(document);
+    const script = document.querySelector('script[type="application/ld+json"][data-nojs]');
+    expect(script).not.toBeNull();
+    expect(script.textContent).toContain("WebPage");
+  });
+
+  test("updates managed jsonld script without duplicating", () => {
+    const existing = document.createElement("script");
+    existing.type = "application/ld+json";
+    existing.setAttribute("data-nojs", "");
+    existing.textContent = '{"@type":"Old"}';
+    document.head.appendChild(existing);
+    document.body.innerHTML = `<div hidden page-jsonld>{"@type":"New"}</div>`;
+    applyHeadAttrs(document);
+    const scripts = document.querySelectorAll('script[type="application/ld+json"][data-nojs]');
+    expect(scripts.length).toBe(1);
+    expect(scripts[0].textContent).toContain('"New"');
+  });
+
+  test("does not touch hand-written jsonld (no data-nojs)", () => {
+    const manual = document.createElement("script");
+    manual.type = "application/ld+json";
+    manual.textContent = '{"@type":"Manual"}';
+    document.head.appendChild(manual);
+    document.body.innerHTML = `<div hidden page-jsonld>{"@type":"Managed"}</div>`;
+    applyHeadAttrs(document);
+    const all = document.querySelectorAll('script[type="application/ld+json"]');
+    expect(all.length).toBe(2);
+    expect(all[0].textContent).toContain("Manual");
+  });
+});
+
+// ── template[route] head attributes ──────────────────────────────────────────
+
+describe("inject-head-attrs — template[route] head attributes", () => {
+  test("injects title from root route template (SPA default)", () => {
+    document.body.innerHTML = `
+      <div route-view></div>
+      <template route="/" page-title="'Home | Store'"><h1>Home</h1></template>
+      <template route="/about" page-title="'About | Store'"><h1>About</h1></template>
+    `;
+    applyHeadAttrs(document);
+    expect(document.querySelector("title").textContent).toBe("Home | Store");
+  });
+
+  test("injects all four attrs from a single route template", () => {
+    document.body.innerHTML = `
+      <div route-view></div>
+      <template route="/"
+        page-title="'Home | Store'"
+        page-description="'Welcome to our store'"
+        page-canonical="'/'"
+        page-jsonld='{"@type":"WebSite","name":"Store"}'>
+        <h1>Home</h1>
+      </template>
+    `;
+    applyHeadAttrs(document);
+    expect(document.querySelector("title").textContent).toBe("Home | Store");
+    expect(document.querySelector('meta[name="description"]').content).toBe("Welcome to our store");
+    expect(document.querySelector('link[rel="canonical"]').getAttribute("href")).toContain("/");
+    const script = document.querySelector('script[type="application/ld+json"][data-nojs]');
+    expect(script.textContent).toContain("WebSite");
+  });
+
+  test("body directive takes precedence over route template attribute", () => {
+    document.body.innerHTML = `
+      <div hidden page-title="'Body Title'"></div>
+      <template route="/" page-title="'Route Title'"><h1>Home</h1></template>
+    `;
+    applyHeadAttrs(document);
+    expect(document.querySelector("title").textContent).toBe("Body Title");
+  });
+
+  test("skips dynamic route template expressions", () => {
+    const existing = document.createElement("title");
+    existing.textContent = "Default";
+    document.head.appendChild(existing);
+    document.body.innerHTML = `
+      <template route="/" page-title="'Home | ' + $store.name"><h1>Home</h1></template>
+    `;
+    applyHeadAttrs(document);
+    expect(document.querySelector("title").textContent).toBe("Default");
+  });
+
+  test("uses only one route template in SPA context (ignores non-default routes)", () => {
+    document.body.innerHTML = `
+      <template route="/" page-title="'Home'" page-description="'Home desc'"></template>
+      <template route="/about" page-title="'About'" page-description="'About desc'"></template>
+    `;
+    applyHeadAttrs(document);
+    expect(document.querySelector("title").textContent).toBe("Home");
+    expect(document.querySelector('meta[name="description"]').content).toBe("Home desc");
+  });
+});

--- a/docs/md/build-tools.md
+++ b/docs/md/build-tools.md
@@ -1,0 +1,190 @@
+# Build Tools
+
+No.JS ships two optional post-build scripts that pre-populate `<head>` in
+your generated HTML files. Both scripts are designed to be run after your
+bundler produces the `dist/` directory.
+
+> **Why bother?** No.JS directives run in the browser — on the very first
+> request, a crawler or browser receives HTML whose `<head>` may be empty.
+> Build-time injection fills those tags *before any JavaScript runs*, which
+> matters for:
+>
+> - **SEO**: Googlebot and other crawlers index the initial HTML response.
+> - **Social sharing**: Open Graph / Twitter Card parsers do not execute JS.
+> - **LCP / TTFB**: `<link rel="preload">` hints only help if they arrive in
+>   the initial HTML — hints injected by JS fire too late for the first load.
+
+The two scripts are complementary and intended to be run together:
+
+```json
+"scripts": {
+  "build": "node build.js && node scripts/inject-head-attrs.js && node scripts/inject-resource-hints.js"
+}
+```
+
+---
+
+## `scripts/inject-head-attrs.js`
+
+**What it does:** Scans every `.html` file in `dist/` and injects or updates
+`<title>`, `<meta name="description">`, `<link rel="canonical">`, and
+`<script type="application/ld+json" data-nojs>` for No.JS head-management
+directives that contain **static values**.
+
+**Related PRs / features:**
+- [Head Management directives](head-management.md) — `page-title`,
+  `page-description`, `page-canonical`, `page-jsonld` as body directives
+  (PR #27).
+- [Route head attributes](routing.md#route-head-attributes) — the same four
+  attributes declared directly on `<template route>` elements (PR #34).
+
+### Usage
+
+```sh
+# Default: scans dist/**/*.html
+node scripts/inject-head-attrs.js
+
+# Custom glob
+node scripts/inject-head-attrs.js "public/**/*.html"
+```
+
+### What is injectable at build time
+
+Only **static string literals** can be resolved without executing JavaScript:
+
+| Expression | Injectable? | Reason |
+|---|---|---|
+| `page-title="'About Us \| Store'"` | ✅ Yes | Bare string literal |
+| `page-canonical="'/about'"` | ✅ Yes | Bare string literal |
+| `page-jsonld` body content | ✅ Always | JSON is verbatim, no evaluation |
+| `page-title="product.name + ' \| Store'"` | ❌ No | Depends on runtime state |
+| `page-description="product.description"` | ❌ No | Variable reference |
+| `page-canonical="'/products/' + product.slug"` | ❌ No | Expression |
+
+Dynamic directives are left in the DOM untouched — the runtime will evaluate
+them as usual when the page loads.
+
+### Body directives example
+
+```html
+<!-- Static: injected at build time AND updated at runtime (reactive) -->
+<div hidden page-title="'About Us | My Store'"></div>
+<div hidden page-description="'We sell the best products online'"></div>
+<div hidden page-canonical="'/about'"></div>
+<div hidden page-jsonld>{"@context":"https://schema.org","@type":"WebPage","name":"About Us"}</div>
+
+<!-- Dynamic: only updated at runtime -->
+<div hidden page-title="product.name + ' | My Store'"></div>
+```
+
+After the build script runs:
+
+```html
+<head>
+  <title>About Us | My Store</title>
+  <meta name="description" content="We sell the best products online">
+  <link rel="canonical" href="/about">
+  <script type="application/ld+json" data-nojs>{"@context":"https://schema.org","@type":"WebPage","name":"About Us"}</script>
+</head>
+```
+
+### Route template example (SPA)
+
+For a standard SPA with a single `index.html`, the script uses the root route
+(`route="/"`) as the default page metadata:
+
+```html
+<template route="/"
+  page-title="'My Store — Home'"
+  page-description="'Shop our full catalogue'"
+  page-canonical="'https://mystore.com/'"
+  page-jsonld='{"@context":"https://schema.org","@type":"WebSite","name":"My Store"}'>
+  <h1>Home</h1>
+</template>
+```
+
+Resulting `<head>` after the script runs:
+
+```html
+<head>
+  <title>My Store — Home</title>
+  <meta name="description" content="Shop our full catalogue">
+  <link rel="canonical" href="https://mystore.com/">
+  <script type="application/ld+json" data-nojs>{"@context":"https://schema.org","@type":"WebSite","name":"My Store"}</script>
+</head>
+```
+
+### Route template example (SSG)
+
+When using a static site generator that produces one HTML file per route (see
+[SSG guide](ssg.md)), each file contains only the relevant `<template route>`
+element. The script processes each file independently:
+
+```
+dist/
+  index.html          ← contains <template route="/" page-title="'Home | Store'">
+  about/index.html    ← contains <template route="/about" page-title="'About | Store'">
+  products/index.html ← contains <template route="/products" page-title="'Products | Store'">
+```
+
+Each file gets its own correct `<title>` and metadata injected.
+
+### Precedence
+
+If both a body directive and a route template attribute are present for the
+same element, the **body directive takes precedence**:
+
+```html
+<!-- Body directive wins -->
+<div hidden page-title="'Explicit Title'"></div>
+<template route="/" page-title="'Route Title'">...</template>
+<!-- → <title>Explicit Title</title> -->
+```
+
+---
+
+## `scripts/inject-resource-hints.js`
+
+**What it does:** Scans every `.html` file in `dist/` and injects
+`<link rel="preload">`, `<link rel="preconnect">`, and
+`<link rel="prefetch">` hints for No.JS `get=` directives and remote route
+templates.
+
+**Related PR / feature:** [Resource Hints](resource-hints.md) (PR #33).
+
+### Usage
+
+```sh
+node scripts/inject-resource-hints.js
+
+# Custom glob
+node scripts/inject-resource-hints.js "public/**/*.html"
+```
+
+See [Resource Hints →](resource-hints.md) for full documentation.
+
+---
+
+## Dependencies
+
+Both scripts use `jsdom` and `glob`, which are already `devDependencies` in
+`package.json` (used by the test suite). No additional packages are needed.
+
+---
+
+## Running both scripts
+
+```json
+{
+  "scripts": {
+    "build": "node build.js",
+    "postbuild": "node scripts/inject-head-attrs.js && node scripts/inject-resource-hints.js"
+  }
+}
+```
+
+Using `postbuild` ensures the scripts run automatically after every `npm run build`.
+
+---
+
+**Next:** [Head Management →](head-management.md) | [Resource Hints →](resource-hints.md)

--- a/scripts/inject-head-attrs.js
+++ b/scripts/inject-head-attrs.js
@@ -1,0 +1,220 @@
+#!/usr/bin/env node
+// ─────────────────────────────────────────────────────────────────────────────
+//  No.JS — inject-head-attrs
+//
+//  Post-build script that scans .html files in dist/ and pre-populates <head>
+//  elements for No.JS head-management directives that carry static values.
+//
+//  Why this script exists
+//  ──────────────────────
+//  The head-management directives (page-title, page-description, page-canonical,
+//  page-jsonld — see PR #27) and the route head attributes on <template route>
+//  (PR #34) run at runtime in the browser. That means on the very first load,
+//  a crawler or browser sees the <head> without any metadata until JavaScript
+//  executes. This script fills in the gap at build time for values that are
+//  known statically, so the initial HTML payload already contains the correct
+//  <title>, <meta name="description">, <link rel="canonical">, and
+//  <script type="application/ld+json"> before any JS runs.
+//
+//  Companion script: scripts/inject-resource-hints.js (PR #33) handles
+//  <link rel="preload|preconnect|prefetch"> for API and template URLs.
+//  Run both as part of your build pipeline for maximum effect.
+//
+//  What is injectable
+//  ──────────────────
+//  Only static string literals are processed:
+//
+//    ✅  page-title="'About Us | Store'"        — injected
+//    ✅  page-canonical="'/about'"              — injected
+//    ✅  page-jsonld body (always JSON)         — injected
+//    ❌  page-title="product.name + ' | Store'" — dynamic, skip (runtime handles it)
+//    ❌  page-description="product.description" — dynamic, skip (runtime handles it)
+//
+//  For <template route> head attributes (SSG context):
+//  In a server-side-generated site where each route has its own HTML file, the
+//  corresponding <template route> element is already present in the file and
+//  this script injects its static head attrs. In a standard SPA (single
+//  index.html), only the root route template (route="/") is used as a fallback.
+//
+//  Usage
+//  ──────────────────
+//    node scripts/inject-head-attrs.js
+//    node scripts/inject-head-attrs.js "dist/**/*.html"
+//
+//  Typical package.json setup:
+//    "build": "node build.js && node scripts/inject-head-attrs.js && node scripts/inject-resource-hints.js"
+//
+//  See docs/md/build-tools.md for full documentation.
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { readFileSync, writeFileSync } from "fs";
+import { globSync } from "glob";
+import { JSDOM } from "jsdom";
+
+const pattern = process.argv[2] || "dist/**/*.html";
+const files = globSync(pattern);
+
+if (files.length === 0) {
+  console.warn(`[no-js/head-attrs] No HTML files matched: ${pattern}`);
+  process.exit(0);
+}
+
+// Returns the string value for a JS string literal expression ('foo' or "foo").
+// Returns null for any other expression (dynamic, complex, etc.).
+function extractLiteral(expr) {
+  if (!expr) return null;
+  const m = expr.trim().match(/^(['"])([\s\S]*)\1$/);
+  return m ? m[2] : null;
+}
+
+// Injects or updates a <title> element in <head>.
+function setTitle(head, document, value) {
+  let el = head.querySelector("title");
+  if (!el) {
+    el = document.createElement("title");
+    head.appendChild(el);
+  }
+  el.textContent = value;
+}
+
+// Injects or updates <meta name="description">.
+function setDescription(head, document, value) {
+  let el = head.querySelector('meta[name="description"]');
+  if (!el) {
+    el = document.createElement("meta");
+    el.name = "description";
+    head.appendChild(el);
+  }
+  el.content = value;
+}
+
+// Injects or updates <link rel="canonical">.
+function setCanonical(head, document, value) {
+  let el = head.querySelector('link[rel="canonical"]');
+  if (!el) {
+    el = document.createElement("link");
+    el.rel = "canonical";
+    head.appendChild(el);
+  }
+  el.href = value;
+}
+
+// Injects or updates <script type="application/ld+json" data-nojs>.
+function setJsonLd(head, document, json) {
+  let el = head.querySelector('script[type="application/ld+json"][data-nojs]');
+  if (!el) {
+    el = document.createElement("script");
+    el.type = "application/ld+json";
+    el.setAttribute("data-nojs", "");
+    head.appendChild(el);
+  }
+  el.textContent = json;
+}
+
+let totalFiles = 0;
+let totalInjected = 0;
+
+for (const file of files) {
+  const html = readFileSync(file, "utf8");
+  const dom = new JSDOM(html);
+  const { document } = dom.window;
+  const head = document.head;
+  let injected = 0;
+
+  // ── Body directives (M1 — PR #27) ─────────────────────────────────────────
+  // These are placed as <div hidden page-title="..."> anywhere in the body.
+  // Only static string literals are injectable; dynamic expressions are skipped.
+
+  // :not(template[route]) excludes route template head attributes — those are
+  // handled below with their own precedence logic.
+  for (const el of document.querySelectorAll("[page-title]:not(template[route])")) {
+    const val = extractLiteral(el.getAttribute("page-title"));
+    if (val == null) continue;
+    setTitle(head, document, val);
+    injected++;
+  }
+
+  for (const el of document.querySelectorAll("[page-description]:not(template[route])")) {
+    const val = extractLiteral(el.getAttribute("page-description"));
+    if (val == null) continue;
+    setDescription(head, document, val);
+    injected++;
+  }
+
+  for (const el of document.querySelectorAll("[page-canonical]:not(template[route])")) {
+    const val = extractLiteral(el.getAttribute("page-canonical"));
+    if (val == null) continue;
+    setCanonical(head, document, val);
+    injected++;
+  }
+
+  // page-jsonld: JSON lives in the element body — always static, always injectable.
+  for (const el of document.querySelectorAll("[page-jsonld]:not(template[route])")) {
+    const json = (el.textContent || el.innerHTML).trim();
+    if (!json) continue;
+    setJsonLd(head, document, json);
+    injected++;
+  }
+
+  // ── Route template head attributes (M8 — PR #34, extends M6 — PR #32) ─────
+  // <template route="/about" page-title="'About'" page-description="'...'">
+  //
+  // SSG context: each route's HTML file contains the relevant <template route>.
+  // The script processes all <template route> elements found in the file.
+  // Body directives (above) take precedence if both are present.
+  //
+  // SPA context (single index.html): only the root route (route="/") is used
+  // as a default fallback for the initial page load.
+
+  const routeTemplates = [...document.querySelectorAll("template[route]")];
+
+  // Prefer an exact "/" route for the SPA default; otherwise use first found.
+  const defaultTpl =
+    routeTemplates.find((t) => t.getAttribute("route") === "/") ||
+    routeTemplates[0];
+
+  for (const tpl of routeTemplates) {
+    // In SSG context every template in the file is relevant; in SPA context
+    // we only apply the default route's metadata to avoid clobbering.
+    const isSpaDefault = tpl === defaultTpl;
+    const isOnlyTemplate = routeTemplates.length === 1;
+    if (!isSpaDefault && !isOnlyTemplate) continue;
+
+    // Only apply if no body directive already handled it.
+    // Use :not(template[route]) so the guard doesn't match the template itself.
+    const titleVal = extractLiteral(tpl.getAttribute("page-title"));
+    if (titleVal != null && !document.querySelector("[page-title]:not(template[route])")) {
+      setTitle(head, document, titleVal);
+      injected++;
+    }
+
+    const descVal = extractLiteral(tpl.getAttribute("page-description"));
+    if (descVal != null && !document.querySelector("[page-description]:not(template[route])")) {
+      setDescription(head, document, descVal);
+      injected++;
+    }
+
+    const canonicalVal = extractLiteral(tpl.getAttribute("page-canonical"));
+    if (canonicalVal != null && !document.querySelector("[page-canonical]:not(template[route])")) {
+      setCanonical(head, document, canonicalVal);
+      injected++;
+    }
+
+    const jsonldAttr = tpl.getAttribute("page-jsonld");
+    if (jsonldAttr && !document.querySelector("[page-jsonld]:not(template[route])")) {
+      setJsonLd(head, document, jsonldAttr);
+      injected++;
+    }
+  }
+
+  if (injected > 0) {
+    writeFileSync(file, dom.serialize(), "utf8");
+    console.log(`[no-js/head-attrs] ${file}: injected ${injected} head element(s)`);
+    totalFiles++;
+    totalInjected += injected;
+  }
+}
+
+console.log(
+  `[no-js/head-attrs] Done — ${totalInjected} element(s) across ${totalFiles} file(s).`
+);


### PR DESCRIPTION
## Why this PR exists

No.JS head-management directives (#27) and route head attributes (#34) run at runtime in the browser. On the very first request, a crawler or browser receives HTML with an empty `<head>` — metadata only appears after JavaScript executes. This is a gap for:

- **SEO**: Googlebot indexes the initial HTML response, not the JS-rendered state.
- **Social sharing**: Open Graph / Twitter Card parsers do not execute JS.

This PR adds `scripts/inject-head-attrs.js`, a post-build script that pre-populates `<head>` for directives whose values are **static string literals** — filling the gap before JS runs, while leaving dynamic expressions for the runtime to handle as usual.

It is the companion to `scripts/inject-resource-hints.js` from PR #33 (resource hints), intended to run together as a `postbuild` step.

## What the script does

Scans `dist/**/*.html` (or a custom glob) and injects or updates:

| Tag | Trigger |
|---|---|
| `<title>` | `page-title="'static'"` on any element OR `<template route="/" page-title="'static'">` |
| `<meta name="description">` | `page-description="'static'"` |
| `<link rel="canonical">` | `page-canonical="'/path'"` |
| `<script type="application/ld+json" data-nojs>` | `page-jsonld` body content (always static) |

Only bare string literals (`'foo'` / `"foo"`) are processed. Expressions like `product.name + ' | Store'` are silently skipped and evaluated at runtime as normal.

For `<template route>` attributes (PR #34 / PR #32): in a standard SPA the root route (`route="/"`) is used as the default page metadata. In SSG where each route has its own HTML file, every file is processed independently.

Body directives take precedence over route template attributes when both are present.

## Related PRs

| PR | Feature | Relationship |
|---|---|---|
| #27 (M1) | Head Management body directives | Primary source of `page-*` attributes this script reads |
| #32 (M6) | `page-title` on `<template route>` | Subset of #34 |
| #33 (M7) | Resource hints build script | Companion — run both in `postbuild` |
| #34 | All four head attrs on `<template route>` | Extended source this script also reads |

## Usage

```sh
node scripts/inject-head-attrs.js
# or with custom glob:
node scripts/inject-head-attrs.js "public/**/*.html"
```

Recommended `package.json` setup:

```json
{
  "scripts": {
    "build": "node build.js",
    "postbuild": "node scripts/inject-head-attrs.js && node scripts/inject-resource-hints.js"
  }
}
```

No new dependencies — `jsdom` and `glob` are already devDependencies (used by the test suite).

## Documentation

Added `docs/md/build-tools.md` covering both post-build scripts, with:
- What is and isn't injectable at build time (table)
- Body directive example with before/after `<head>`
- SPA and SSG usage patterns
- Precedence rules
- Reference to [Head Management](docs/md/head-management.md) and [Resource Hints](docs/md/resource-hints.md)

## Test plan

- [x] `extractLiteral` detects single/double-quoted string literals
- [x] `extractLiteral` returns null for dynamic expressions and variable references
- [x] `page-title` injected from static literal; existing `<title>` updated in place
- [x] Dynamic `page-title` expression skipped
- [x] `page-description` created / updated without duplicating
- [x] Dynamic `page-description` skipped
- [x] `page-canonical` created / updated without duplicating
- [x] Dynamic `page-canonical` skipped
- [x] `page-jsonld` body injected; existing managed script updated; hand-written script untouched
- [x] Root route template title injected as SPA default
- [x] All four route template attrs injected from single template
- [x] Body directive takes precedence over route template attribute
- [x] Dynamic route template expression skipped
- [x] Non-default route templates ignored in SPA context
- [x] Full suite: 1236 tests pass