### PR TITLE
NOJS-10: Documentation for View Transition API

### DIFF
--- a/docs/locales/en/docs.json
+++ b/docs/locales/en/docs.json
@@ -190,7 +190,8 @@
         "i18nNs": "Auto-derive i18n namespace from route filename",
         "routeViewSrc": "File-based routing outlet",
         "routeIndex": "Filename for root <code>/</code> (default <code>\"index\"</code>)",
-        "routeExt": "File extension (default <code>\".tpl\"</code>, fallback <code>\".html\"</code>)"
+        "routeExt": "File extension (default <code>\".tpl\"</code>, fallback <code>\".html\"</code>)",
+        "transitionVT": "View Transition API preset on route-view (slide, fade, scale, none)"
       },
       "animation": {
         "title": "Animation",
@@ -202,7 +203,8 @@
         "animateLeave": "Leave animation",
         "animateDuration": "Duration in ms",
         "animateStagger": "Stagger delay",
-        "transition": "CSS transition"
+        "transition": "CSS transition (class-based, for regular elements)",
+        "transitionVT": "View Transition API preset on route-view (slide, fade, scale, none)"
       },
       "dnd": {
         "title": "Drag and Drop",
@@ -725,6 +727,31 @@
         "futureText": "Currently only <code>'auto'</code> is supported. Future versions may add <code>'none'</code> (opt out) and <code>'target'</code> (focus a specific selector).",
         "ariaLiveTitle": "ARIA Live Region",
         "ariaLiveText": "For screen readers that don't respond to focus changes, add <code>aria-live=\"polite\"</code> to your <code>route-view</code>. The browser will announce new content as it appears:"
+      },
+      "viewTransitions": {
+        "title": "View Transitions",
+        "text": "The <code>transition</code> attribute on <code>route-view</code> now uses the <strong>View Transition API</strong> by default. Just pick a preset name and route changes are animated natively by the browser — no manual CSS required.",
+        "presetsTitle": "Built-in Presets",
+        "presetsText": "No.JS ships with four built-in transition presets:",
+        "colPreset": "Preset",
+        "colEffect": "Effect",
+        "presetSlide": "Directional slide — content slides left/right based on navigation direction (forward/backward)",
+        "presetFade": "Crossfade — old content fades out while new content fades in",
+        "presetScale": "Scale zoom — old content scales down while new content scales up",
+        "presetNone": "Instant swap — no animation, content replaces immediately",
+        "configTitle": "Configuration",
+        "configText": "The View Transition API is <strong>enabled by default</strong> via <code>router.viewTransition: true</code>. Set it to <code>false</code> to fall back to the legacy class-based transition system.",
+        "customCssTitle": "Custom CSS",
+        "customCssText": "For custom animations, target the <code>::view-transition-old(route-content)</code> and <code>::view-transition-new(route-content)</code> pseudo-elements. The <code>view-transition-name: route-content</code> is set automatically on any outlet with a <code>transition</code> attribute.",
+        "howItWorksTitle": "How it Works",
+        "howItWorksText": "When a route change occurs with a <code>transition</code> preset:",
+        "howStep1": "The router detects navigation direction (<strong>forward</strong> or <strong>backward</strong>) from the history stack",
+        "howStep2": "<code>document.startViewTransition()</code> is called, capturing the current outlet state",
+        "howStep3": "The new route content is rendered inside the outlet",
+        "howStep4": "The browser animates between old and new snapshots using the preset CSS rules",
+        "deprecationTitle": "Migration from Class-Based Transitions",
+        "deprecationText": "The old class-based transition system (<code>*-enter</code>, <code>*-enter-active</code>, <code>*-leave</code>, etc.) on <code>route-view</code> is <strong>deprecated</strong>. It still works when <code>router.viewTransition</code> is set to <code>false</code>, but the View Transition API is the recommended approach going forward.",
+        "deprecationCallout": "<strong>Migration is mostly automatic.</strong> If you already use <code>transition=\"fade\"</code> on a <code>route-view</code>, it now uses the View Transition API by default — no code changes needed. Your custom <code>.fade-enter</code> / <code>.fade-leave</code> CSS is simply ignored (unless you set <code>viewTransition: false</code>)."
       }
     },
     "formsValidation": {
@@ -850,6 +877,7 @@
       },
       "transition": {
         "title": "transition — CSS Transition Classes",
+        "viewTransitionNote": "<strong>Note:</strong> Route transitions on <code>route-view</code> now use the <a href=\"/docs/routing#view-transitions\">View Transition API</a> by default. The class-based <code>transition</code> attribute described below still applies to <strong>regular elements</strong> (e.g. <code>if</code>, <code>show</code>).",
         "text1": "Follows a convention similar to Vue's transition system.",
         "text2": "No.JS adds/removes classes during the transition:",
         "col1": "Class",

--- a/docs/locales/es/docs.json
+++ b/docs/locales/es/docs.json
@@ -190,7 +190,8 @@
         "i18nNs": "Auto-derivar namespace i18n del nombre de archivo de ruta",
         "routeViewSrc": "Outlet de enrutamiento basado en archivos",
         "routeIndex": "Nombre de archivo para la raíz <code>/</code> (por defecto <code>\"index\"</code>)",
-        "routeExt": "Extensión de archivo (por defecto <code>\".tpl\"</code>, respaldo <code>\".html\"</code>)"
+        "routeExt": "Extensión de archivo (por defecto <code>\".tpl\"</code>, respaldo <code>\".html\"</code>)",
+        "transitionVT": "Preset View Transition API en route-view (slide, fade, scale, none)"
       },
       "animation": {
         "title": "Animación",
@@ -202,7 +203,8 @@
         "animateLeave": "Animación de salida",
         "animateDuration": "Duración en ms",
         "animateStagger": "Retraso escalonado",
-        "transition": "Transición CSS"
+        "transition": "Transición CSS (basada en clases, para elementos regulares)",
+        "transitionVT": "Preset View Transition API en route-view (slide, fade, scale, none)"
       },
       "dnd": {
         "title": "Drag and Drop",
@@ -725,6 +727,31 @@
         "futureText": "Actualmente solo se admite <code>'auto'</code>. Versiones futuras pueden agregar <code>'none'</code> (desactivar) y <code>'target'</code> (enfocar un selector específico).",
         "ariaLiveTitle": "Región ARIA Live",
         "ariaLiveText": "Para lectores de pantalla que no responden a cambios de foco, agrega <code>aria-live=\"polite\"</code> a tu <code>route-view</code>. El navegador anunciará el nuevo contenido cuando aparezca:"
+      },
+      "viewTransitions": {
+        "title": "View Transitions",
+        "text": "El atributo <code>transition</code> en <code>route-view</code> ahora usa la <strong>View Transition API</strong> por defecto. Solo elige un nombre de preset y los cambios de ruta se animan nativamente por el navegador — sin CSS manual.",
+        "presetsTitle": "Presets Integrados",
+        "presetsText": "No.JS incluye cuatro presets de transición integrados:",
+        "colPreset": "Preset",
+        "colEffect": "Efecto",
+        "presetSlide": "Slide direccional — el contenido se desliza izquierda/derecha según la dirección de navegación (forward/backward)",
+        "presetFade": "Crossfade — el contenido anterior se desvanece mientras el nuevo aparece",
+        "presetScale": "Scale zoom — el contenido anterior se reduce mientras el nuevo se amplía",
+        "presetNone": "Cambio instantáneo — sin animación, el contenido se reemplaza inmediatamente",
+        "configTitle": "Configuración",
+        "configText": "La View Transition API está <strong>habilitada por defecto</strong> vía <code>router.viewTransition: true</code>. Configúrala como <code>false</code> para volver al sistema legacy de transiciones basado en clases CSS.",
+        "customCssTitle": "CSS Personalizado",
+        "customCssText": "Para animaciones personalizadas, apunta a los pseudo-elementos <code>::view-transition-old(route-content)</code> y <code>::view-transition-new(route-content)</code>. El <code>view-transition-name: route-content</code> se establece automáticamente en cualquier outlet con atributo <code>transition</code>.",
+        "howItWorksTitle": "Cómo Funciona",
+        "howItWorksText": "Cuando ocurre un cambio de ruta con un preset <code>transition</code>:",
+        "howStep1": "El router detecta la dirección de navegación (<strong>forward</strong> o <strong>backward</strong>) desde la pila de historial",
+        "howStep2": "<code>document.startViewTransition()</code> es invocado, capturando el estado actual del outlet",
+        "howStep3": "El nuevo contenido de la ruta se renderiza dentro del outlet",
+        "howStep4": "El navegador anima entre los snapshots antiguo y nuevo usando las reglas CSS del preset",
+        "deprecationTitle": "Migración desde Transiciones Basadas en Clases",
+        "deprecationText": "El sistema antiguo de transiciones basado en clases (<code>*-enter</code>, <code>*-enter-active</code>, <code>*-leave</code>, etc.) en <code>route-view</code> está <strong>deprecated</strong>. Aún funciona cuando <code>router.viewTransition</code> está configurado como <code>false</code>, pero la View Transition API es el enfoque recomendado.",
+        "deprecationCallout": "<strong>La migración es prácticamente automática.</strong> Si ya usas <code>transition=\"fade\"</code> en un <code>route-view</code>, ahora usa la View Transition API por defecto — sin cambios de código necesarios. Tu CSS personalizado <code>.fade-enter</code> / <code>.fade-leave</code> simplemente se ignora (a menos que configures <code>viewTransition: false</code>)."
       }
     },
     "formsValidation": {
@@ -850,6 +877,7 @@
       },
       "transition": {
         "title": "transition — Clases de Transición CSS",
+        "viewTransitionNote": "<strong>Nota:</strong> Las transiciones de ruta en <code>route-view</code> ahora usan la <a href=\"/docs/routing#view-transitions\">View Transition API</a> por defecto. El atributo <code>transition</code> basado en clases descrito a continuación aún se aplica a <strong>elementos regulares</strong> (ej: <code>if</code>, <code>show</code>).",
         "text1": "Sigue una convención similar al sistema de transiciones de Vue.",
         "text2": "No.JS agrega/elimina clases durante la transición:",
         "col1": "Clase",

--- a/docs/locales/fr/docs.json
+++ b/docs/locales/fr/docs.json
@@ -190,7 +190,8 @@
         "i18nNs": "Dérivation automatique du namespace i18n à partir du nom de fichier de route",
         "routeViewSrc": "Point de sortie de routage basé sur les fichiers",
         "routeIndex": "Nom de fichier pour la racine <code>/</code> (défaut <code>\"index\"</code>)",
-        "routeExt": "Extension de fichier (défaut <code>\".tpl\"</code>, repli <code>\".html\"</code>)"
+        "routeExt": "Extension de fichier (défaut <code>\".tpl\"</code>, repli <code>\".html\"</code>)",
+        "transitionVT": "Preset View Transition API sur route-view (slide, fade, scale, none)"
       },
       "animation": {
         "title": "Animation",
@@ -202,7 +203,8 @@
         "animateLeave": "Animation de sortie",
         "animateDuration": "Durée en ms",
         "animateStagger": "Délai d'échelonnement",
-        "transition": "Transition CSS"
+        "transition": "Transition CSS (basée sur les classes, pour les éléments réguliers)",
+        "transitionVT": "Preset View Transition API sur route-view (slide, fade, scale, none)"
       },
       "dnd": {
         "title": "Drag and Drop",
@@ -725,6 +727,31 @@
         "futureText": "Actuellement seul <code>'auto'</code> est pris en charge. Les versions futures pourraient ajouter <code>'none'</code> (désactiver) et <code>'target'</code> (focaliser un sélecteur spécifique).",
         "ariaLiveTitle": "Région ARIA Live",
         "ariaLiveText": "Pour les lecteurs d'écran qui ne répondent pas aux changements de focus, ajoutez <code>aria-live=\"polite\"</code> à votre <code>route-view</code>. Le navigateur annoncera le nouveau contenu à son apparition :"
+      },
+      "viewTransitions": {
+        "title": "View Transitions",
+        "text": "L'attribut <code>transition</code> sur <code>route-view</code> utilise maintenant la <strong>View Transition API</strong> par défaut. Choisissez simplement un nom de preset et les changements de route sont animés nativement par le navigateur — sans CSS manuel.",
+        "presetsTitle": "Presets Intégrés",
+        "presetsText": "No.JS inclut quatre presets de transition intégrés :",
+        "colPreset": "Preset",
+        "colEffect": "Effet",
+        "presetSlide": "Slide directionnel — le contenu glisse gauche/droite selon la direction de navigation (forward/backward)",
+        "presetFade": "Crossfade — l'ancien contenu s'estompe tandis que le nouveau apparaît",
+        "presetScale": "Scale zoom — l'ancien contenu se réduit tandis que le nouveau s'agrandit",
+        "presetNone": "Changement instantané — sans animation, le contenu est remplacé immédiatement",
+        "configTitle": "Configuration",
+        "configText": "La View Transition API est <strong>activée par défaut</strong> via <code>router.viewTransition: true</code>. Réglez sur <code>false</code> pour revenir au système legacy de transitions basé sur les classes CSS.",
+        "customCssTitle": "CSS Personnalisé",
+        "customCssText": "Pour des animations personnalisées, ciblez les pseudo-éléments <code>::view-transition-old(route-content)</code> et <code>::view-transition-new(route-content)</code>. Le <code>view-transition-name: route-content</code> est défini automatiquement sur tout outlet ayant un attribut <code>transition</code>.",
+        "howItWorksTitle": "Comment ça Fonctionne",
+        "howItWorksText": "Lors d'un changement de route avec un preset <code>transition</code> :",
+        "howStep1": "Le router détecte la direction de navigation (<strong>forward</strong> ou <strong>backward</strong>) depuis la pile d'historique",
+        "howStep2": "<code>document.startViewTransition()</code> est appelé, capturant l'état actuel de l'outlet",
+        "howStep3": "Le nouveau contenu de la route est rendu à l'intérieur de l'outlet",
+        "howStep4": "Le navigateur anime entre les snapshots ancien et nouveau en utilisant les règles CSS du preset",
+        "deprecationTitle": "Migration depuis les Transitions Basées sur les Classes",
+        "deprecationText": "L'ancien système de transitions basé sur les classes (<code>*-enter</code>, <code>*-enter-active</code>, <code>*-leave</code>, etc.) sur <code>route-view</code> est <strong>deprecated</strong>. Il fonctionne toujours quand <code>router.viewTransition</code> est réglé sur <code>false</code>, mais la View Transition API est l'approche recommandée.",
+        "deprecationCallout": "<strong>La migration est pratiquement automatique.</strong> Si vous utilisez déjà <code>transition=\"fade\"</code> sur un <code>route-view</code>, il utilise maintenant la View Transition API par défaut — aucun changement de code nécessaire. Votre CSS personnalisé <code>.fade-enter</code> / <code>.fade-leave</code> est simplement ignoré (sauf si vous définissez <code>viewTransition: false</code>)."
       }
     },
     "formsValidation": {
@@ -850,6 +877,7 @@
       },
       "transition": {
         "title": "transition — Classes de transition CSS",
+        "viewTransitionNote": "<strong>Note :</strong> Les transitions de route sur <code>route-view</code> utilisent maintenant la <a href=\"/docs/routing#view-transitions\">View Transition API</a> par défaut. L'attribut <code>transition</code> basé sur les classes décrit ci-dessous s'applique toujours aux <strong>éléments réguliers</strong> (ex : <code>if</code>, <code>show</code>).",
         "text1": "Suit une convention similaire au système de transition de Vue.",
         "text2": "No.JS ajoute/supprime des classes pendant la transition :",
         "col1": "Classe",

--- a/docs/locales/it/docs.json
+++ b/docs/locales/it/docs.json
@@ -190,7 +190,8 @@
         "i18nNs": "Auto-derivazione del namespace i18n dal nome del file di rotta",
         "routeViewSrc": "Outlet di routing basato su file",
         "routeIndex": "Nome del file per la radice <code>/</code> (predefinito <code>\"index\"</code>)",
-        "routeExt": "Estensione file (predefinito <code>\".tpl\"</code>, fallback <code>\".html\"</code>)"
+        "routeExt": "Estensione file (predefinito <code>\".tpl\"</code>, fallback <code>\".html\"</code>)",
+        "transitionVT": "Preset View Transition API su route-view (slide, fade, scale, none)"
       },
       "animation": {
         "title": "Animazione",
@@ -202,7 +203,8 @@
         "animateLeave": "Animazione di uscita",
         "animateDuration": "Durata in ms",
         "animateStagger": "Ritardo scaglionato",
-        "transition": "Transizione CSS"
+        "transition": "Transizione CSS (basata su classi, per elementi regolari)",
+        "transitionVT": "Preset View Transition API su route-view (slide, fade, scale, none)"
       },
       "dnd": {
         "title": "Drag and Drop",
@@ -725,6 +727,31 @@
         "futureText": "Attualmente è supportato solo <code>'auto'</code>. Le versioni future potrebbero aggiungere <code>'none'</code> (disabilitare) e <code>'target'</code> (focalizzare un selettore specifico).",
         "ariaLiveTitle": "Regione ARIA Live",
         "ariaLiveText": "Per i lettori di schermo che non rispondono ai cambiamenti di focus, aggiungi <code>aria-live=\"polite\"</code> al tuo <code>route-view</code>. Il browser annuncerà il nuovo contenuto quando appare:"
+      },
+      "viewTransitions": {
+        "title": "View Transitions",
+        "text": "L'attributo <code>transition</code> su <code>route-view</code> ora utilizza la <strong>View Transition API</strong> per impostazione predefinita. Basta scegliere un nome di preset e i cambiamenti di rotta vengono animati nativamente dal browser — senza CSS manuale.",
+        "presetsTitle": "Preset Integrati",
+        "presetsText": "No.JS include quattro preset di transizione integrati:",
+        "colPreset": "Preset",
+        "colEffect": "Effetto",
+        "presetSlide": "Slide direzionale — il contenuto scorre sinistra/destra in base alla direzione di navigazione (forward/backward)",
+        "presetFade": "Crossfade — il vecchio contenuto svanisce mentre il nuovo appare",
+        "presetScale": "Scale zoom — il vecchio contenuto si riduce mentre il nuovo si ingrandisce",
+        "presetNone": "Cambio istantaneo — senza animazione, il contenuto viene sostituito immediatamente",
+        "configTitle": "Configurazione",
+        "configText": "La View Transition API è <strong>abilitata per impostazione predefinita</strong> tramite <code>router.viewTransition: true</code>. Impostala su <code>false</code> per tornare al sistema legacy di transizioni basato su classi CSS.",
+        "customCssTitle": "CSS Personalizzato",
+        "customCssText": "Per animazioni personalizzate, punta ai pseudo-elementi <code>::view-transition-old(route-content)</code> e <code>::view-transition-new(route-content)</code>. Il <code>view-transition-name: route-content</code> viene impostato automaticamente su qualsiasi outlet con attributo <code>transition</code>.",
+        "howItWorksTitle": "Come Funziona",
+        "howItWorksText": "Quando avviene un cambio di rotta con un preset <code>transition</code>:",
+        "howStep1": "Il router rileva la direzione di navigazione (<strong>forward</strong> o <strong>backward</strong>) dallo stack della cronologia",
+        "howStep2": "<code>document.startViewTransition()</code> viene invocato, catturando lo stato attuale dell'outlet",
+        "howStep3": "Il nuovo contenuto della rotta viene renderizzato all'interno dell'outlet",
+        "howStep4": "Il browser anima tra i snapshot vecchio e nuovo utilizzando le regole CSS del preset",
+        "deprecationTitle": "Migrazione dalle Transizioni Basate su Classi",
+        "deprecationText": "Il vecchio sistema di transizioni basato su classi (<code>*-enter</code>, <code>*-enter-active</code>, <code>*-leave</code>, ecc.) su <code>route-view</code> è <strong>deprecated</strong>. Funziona ancora quando <code>router.viewTransition</code> è impostato su <code>false</code>, ma la View Transition API è l'approccio consigliato.",
+        "deprecationCallout": "<strong>La migrazione è praticamente automatica.</strong> Se stai già usando <code>transition=\"fade\"</code> su un <code>route-view</code>, ora utilizza la View Transition API per impostazione predefinita — nessuna modifica al codice necessaria. Il tuo CSS personalizzato <code>.fade-enter</code> / <code>.fade-leave</code> viene semplicemente ignorato (a meno che non imposti <code>viewTransition: false</code>)."
       }
     },
     "formsValidation": {
@@ -850,6 +877,7 @@
       },
       "transition": {
         "title": "transition — Classi di Transizione CSS",
+        "viewTransitionNote": "<strong>Nota:</strong> Le transizioni di rotta su <code>route-view</code> ora utilizzano la <a href=\"/docs/routing#view-transitions\">View Transition API</a> per impostazione predefinita. L'attributo <code>transition</code> basato su classi descritto di seguito si applica ancora agli <strong>elementi regolari</strong> (es: <code>if</code>, <code>show</code>).",
         "text1": "Segue una convenzione simile al sistema di transizioni di Vue.",
         "text2": "No.JS aggiunge/rimuove classi durante la transizione:",
         "col1": "Classe",

--- a/docs/locales/pt/docs.json
+++ b/docs/locales/pt/docs.json
@@ -190,7 +190,8 @@
         "i18nNs": "Auto-derivar namespace i18n do nome do arquivo de rota",
         "routeViewSrc": "Outlet de roteamento baseado em arquivos",
         "routeIndex": "Nome do arquivo para a raiz <code>/</code> (padrão <code>\"index\"</code>)",
-        "routeExt": "Extensão de arquivo (padrão <code>\".tpl\"</code>, fallback <code>\".html\"</code>)"
+        "routeExt": "Extensão de arquivo (padrão <code>\".tpl\"</code>, fallback <code>\".html\"</code>)",
+        "transitionVT": "Preset View Transition API no route-view (slide, fade, scale, none)"
       },
       "animation": {
         "title": "Animação",
@@ -202,7 +203,8 @@
         "animateLeave": "Animação de saída",
         "animateDuration": "Duração em ms",
         "animateStagger": "Atraso escalonado",
-        "transition": "Transição CSS"
+        "transition": "Transição CSS (baseada em classes, para elementos regulares)",
+        "transitionVT": "Preset View Transition API no route-view (slide, fade, scale, none)"
       },
       "dnd": {
         "title": "Drag and Drop",
@@ -725,6 +727,31 @@
         "futureText": "Atualmente apenas <code>'auto'</code> é suportado. Versões futuras podem adicionar <code>'none'</code> (desativar) e <code>'target'</code> (focar um seletor específico).",
         "ariaLiveTitle": "Região ARIA Live",
         "ariaLiveText": "Para leitores de tela que não respondem a mudanças de foco, adicione <code>aria-live=\"polite\"</code> ao seu <code>route-view</code>. O browser anunciará o novo conteúdo quando aparecer:"
+      },
+      "viewTransitions": {
+        "title": "View Transitions",
+        "text": "O atributo <code>transition</code> no <code>route-view</code> agora usa a <strong>View Transition API</strong> por padrão. Basta escolher um nome de preset e as mudanças de rota são animadas nativamente pelo browser — sem CSS manual.",
+        "presetsTitle": "Presets Integrados",
+        "presetsText": "O No.JS inclui quatro presets de transição integrados:",
+        "colPreset": "Preset",
+        "colEffect": "Efeito",
+        "presetSlide": "Slide direcional — o conteúdo desliza para esquerda/direita baseado na direção de navegação (forward/backward)",
+        "presetFade": "Crossfade — o conteúdo antigo desaparece enquanto o novo aparece",
+        "presetScale": "Scale zoom — o conteúdo antigo reduz enquanto o novo amplia",
+        "presetNone": "Troca instantânea — sem animação, o conteúdo é substituído imediatamente",
+        "configTitle": "Configuração",
+        "configText": "A View Transition API está <strong>habilitada por padrão</strong> via <code>router.viewTransition: true</code>. Defina como <code>false</code> para voltar ao sistema legado de transições baseado em classes CSS.",
+        "customCssTitle": "CSS Personalizado",
+        "customCssText": "Para animações personalizadas, utilize os pseudo-elementos <code>::view-transition-old(route-content)</code> e <code>::view-transition-new(route-content)</code>. O <code>view-transition-name: route-content</code> é definido automaticamente em qualquer outlet com atributo <code>transition</code>.",
+        "howItWorksTitle": "Como Funciona",
+        "howItWorksText": "Quando ocorre uma mudança de rota com um preset <code>transition</code>:",
+        "howStep1": "O router detecta a direção de navegação (<strong>forward</strong> ou <strong>backward</strong>) a partir da pilha de histórico",
+        "howStep2": "<code>document.startViewTransition()</code> é chamado, capturando o estado atual do outlet",
+        "howStep3": "O novo conteúdo da rota é renderizado dentro do outlet",
+        "howStep4": "O browser anima entre os snapshots antigo e novo usando as regras CSS do preset",
+        "deprecationTitle": "Migração das Transições Baseadas em Classes",
+        "deprecationText": "O sistema antigo de transição baseado em classes (<code>*-enter</code>, <code>*-enter-active</code>, <code>*-leave</code>, etc.) no <code>route-view</code> está <strong>deprecated</strong>. Ainda funciona quando <code>router.viewTransition</code> está definido como <code>false</code>, mas a View Transition API é a abordagem recomendada.",
+        "deprecationCallout": "<strong>A migração é praticamente automática.</strong> Se você já usa <code>transition=\"fade\"</code> em um <code>route-view</code>, agora usa a View Transition API por padrão — nenhuma alteração de código necessária. Seu CSS customizado <code>.fade-enter</code> / <code>.fade-leave</code> é simplesmente ignorado (a menos que defina <code>viewTransition: false</code>)."
       }
     },
     "formsValidation": {
@@ -850,6 +877,7 @@
       },
       "transition": {
         "title": "transition — Classes de Transição CSS",
+        "viewTransitionNote": "<strong>Nota:</strong> Transições de rota no <code>route-view</code> agora usam a <a href=\"/docs/routing#view-transitions\">View Transition API</a> por padrão. O atributo <code>transition</code> baseado em classes descrito abaixo ainda se aplica a <strong>elementos regulares</strong> (ex: <code>if</code>, <code>show</code>).",
         "text1": "Segue uma convenção similar ao sistema de transição do Vue.",
         "text2": "O No.JS adiciona/remove classes durante a transição:",
         "col1": "Classe",

--- a/docs/templates/docs/animations.tpl
+++ b/docs/templates/docs/animations.tpl
@@ -41,6 +41,9 @@
   <!-- transition -->
   <div class="doc-section">
     <h2 class="doc-title" t="docs.animations.transition.title"></h2>
+    <div class="callout">
+      <p t="docs.animations.transition.viewTransitionNote" t-html></p>
+    </div>
     <p class="doc-text" t="docs.animations.transition.text1"></p>
     <div class="code-block"><pre><span class="hl-tag">&lt;div</span> <span class="hl-attr">if</span>=<span class="hl-str">"show"</span> <span class="hl-attr">transition</span>=<span class="hl-str">"fade"</span><span class="hl-tag">&gt;</span>Content<span class="hl-tag">&lt;/div&gt;</span></pre></div>
 

--- a/docs/templates/docs/cheatsheet.tpl
+++ b/docs/templates/docs/cheatsheet.tpl
@@ -168,6 +168,7 @@
         <tr><td><code>$router.forward()</code></td><td><code>$router.forward()</code></td><td t="docs.cheatsheet.routing.routerForward"></td></tr>
         <tr><td><code>$router.on(fn)</code></td><td><code>$router.on(r =&gt; ...)</code></td><td t="docs.cheatsheet.routing.routerOn"></td></tr>
         <tr><td><code>$router.current</code></td><td><code>$router.current.path</code></td><td t="docs.cheatsheet.routing.routerCurrent"></td></tr>
+        <tr><td><code>transition</code> <small>(route-view)</small></td><td><code>&lt;main route-view transition="slide"&gt;</code></td><td t="docs.cheatsheet.routing.transitionVT"></td></tr>
       </tbody>
     </table>
   </div>
@@ -184,6 +185,7 @@
         <tr><td><code>animate-duration</code></td><td><code>animate-duration="300"</code></td><td t="docs.cheatsheet.animation.animateDuration"></td></tr>
         <tr><td><code>animate-stagger</code></td><td><code>animate-stagger="50"</code></td><td t="docs.cheatsheet.animation.animateStagger"></td></tr>
         <tr><td><code>transition</code></td><td><code>transition="fade"</code></td><td t="docs.cheatsheet.animation.transition"></td></tr>
+        <tr><td><code>transition</code> <small>(route-view)</small></td><td><code>&lt;main route-view transition="slide"&gt;</code></td><td t="docs.cheatsheet.animation.transitionVT"></td></tr>
       </tbody>
     </table>
   </div>

--- a/docs/templates/docs/routing.tpl
+++ b/docs/templates/docs/routing.tpl
@@ -433,5 +433,105 @@
     <div class="code-block"><pre><span class="hl-tag">&lt;div</span> <span class="hl-attr">route-view</span> <span class="hl-attr">aria-live</span>=<span class="hl-str">"polite"</span> <span class="hl-attr">aria-atomic</span>=<span class="hl-str">"true"</span><span class="hl-tag">&gt;&lt;/div&gt;</span></pre></div>
   </div>
 
+  <!-- View Transitions -->
+  <div class="doc-section" id="view-transitions">
+    <h2 class="doc-title" t="docs.routing.viewTransitions.title"></h2>
+    <p class="doc-text" t="docs.routing.viewTransitions.text" t-html></p>
+
+    <div class="code-block"><pre><span class="hl-cmt">&lt;!-- Add a transition preset to your route outlet --&gt;</span>
+<span class="hl-tag">&lt;main</span> <span class="hl-attr">route-view</span> <span class="hl-attr">transition</span>=<span class="hl-str">"slide"</span><span class="hl-tag">&gt;&lt;/main&gt;</span></pre></div>
+
+    <!-- Built-in Presets -->
+    <h3 class="doc-subtitle" t="docs.routing.viewTransitions.presetsTitle"></h3>
+    <p class="doc-text" t="docs.routing.viewTransitions.presetsText"></p>
+    <table class="doc-table">
+      <thead><tr><th t="docs.routing.viewTransitions.colPreset"></th><th t="docs.routing.viewTransitions.colEffect"></th></tr></thead>
+      <tbody>
+        <tr><td><code>slide</code></td><td t="docs.routing.viewTransitions.presetSlide"></td></tr>
+        <tr><td><code>fade</code></td><td t="docs.routing.viewTransitions.presetFade"></td></tr>
+        <tr><td><code>scale</code></td><td t="docs.routing.viewTransitions.presetScale"></td></tr>
+        <tr><td><code>none</code></td><td t="docs.routing.viewTransitions.presetNone"></td></tr>
+      </tbody>
+    </table>
+
+    <div class="code-block"><pre><span class="hl-cmt">&lt;!-- Slide with direction detection --&gt;</span>
+<span class="hl-tag">&lt;main</span> <span class="hl-attr">route-view</span> <span class="hl-attr">transition</span>=<span class="hl-str">"slide"</span><span class="hl-tag">&gt;&lt;/main&gt;</span>
+
+<span class="hl-cmt">&lt;!-- Fade crossfade --&gt;</span>
+<span class="hl-tag">&lt;main</span> <span class="hl-attr">route-view</span> <span class="hl-attr">transition</span>=<span class="hl-str">"fade"</span><span class="hl-tag">&gt;&lt;/main&gt;</span>
+
+<span class="hl-cmt">&lt;!-- Scale zoom effect --&gt;</span>
+<span class="hl-tag">&lt;main</span> <span class="hl-attr">route-view</span> <span class="hl-attr">transition</span>=<span class="hl-str">"scale"</span><span class="hl-tag">&gt;&lt;/main&gt;</span>
+
+<span class="hl-cmt">&lt;!-- Instant swap, no animation --&gt;</span>
+<span class="hl-tag">&lt;main</span> <span class="hl-attr">route-view</span> <span class="hl-attr">transition</span>=<span class="hl-str">"none"</span><span class="hl-tag">&gt;&lt;/main&gt;</span></pre></div>
+
+    <!-- Configuration -->
+    <h3 class="doc-subtitle" t="docs.routing.viewTransitions.configTitle"></h3>
+    <p class="doc-text" t="docs.routing.viewTransitions.configText" t-html></p>
+    <div class="code-block"><pre><span class="hl-cmt">// View Transition API is enabled by default</span>
+<span class="hl-fn">NoJS</span>.<span class="hl-fn">config</span>({
+  <span class="hl-attr">router</span>: { <span class="hl-attr">viewTransition</span>: <span class="hl-kw">true</span> }  <span class="hl-cmt">// default</span>
+});
+
+<span class="hl-cmt">// Fall back to legacy class-based transitions</span>
+<span class="hl-fn">NoJS</span>.<span class="hl-fn">config</span>({
+  <span class="hl-attr">router</span>: { <span class="hl-attr">viewTransition</span>: <span class="hl-kw">false</span> }
+});</pre></div>
+
+    <!-- Custom CSS -->
+    <h3 class="doc-subtitle" t="docs.routing.viewTransitions.customCssTitle"></h3>
+    <p class="doc-text" t="docs.routing.viewTransitions.customCssText" t-html></p>
+    <div class="code-block"><pre><span class="hl-cmt">/* Target the route outlet's view transition */</span>
+<span class="hl-kw">::view-transition-old</span>(<span class="hl-str">route-content</span>) {
+  <span class="hl-attr">animation</span>: <span class="hl-num">0.3s</span> ease-out fade-out;
+}
+<span class="hl-kw">::view-transition-new</span>(<span class="hl-str">route-content</span>) {
+  <span class="hl-attr">animation</span>: <span class="hl-num">0.3s</span> ease-in fade-in;
+}
+
+<span class="hl-cmt">/* Direction-aware styles using active-view-transition-type */</span>
+<span class="hl-kw">:active-view-transition-type</span>(<span class="hl-str">forward</span>) {
+  <span class="hl-kw">::view-transition-old</span>(<span class="hl-str">route-content</span>) {
+    <span class="hl-attr">animation</span>: <span class="hl-num">0.3s</span> slide-out-left;
+  }
+  <span class="hl-kw">::view-transition-new</span>(<span class="hl-str">route-content</span>) {
+    <span class="hl-attr">animation</span>: <span class="hl-num">0.3s</span> slide-in-right;
+  }
+}
+
+<span class="hl-cmt">/* Respect reduced motion */</span>
+<span class="hl-kw">@media</span> (prefers-reduced-motion: reduce) {
+  <span class="hl-kw">::view-transition-old</span>(<span class="hl-str">route-content</span>),
+  <span class="hl-kw">::view-transition-new</span>(<span class="hl-str">route-content</span>) {
+    <span class="hl-attr">animation-duration</span>: <span class="hl-num">0.01ms</span>;
+  }
+}</pre></div>
+
+    <!-- How it Works -->
+    <h3 class="doc-subtitle" t="docs.routing.viewTransitions.howItWorksTitle"></h3>
+    <p class="doc-text" t="docs.routing.viewTransitions.howItWorksText" t-html></p>
+    <ol class="doc-list">
+      <li t="docs.routing.viewTransitions.howStep1" t-html></li>
+      <li t="docs.routing.viewTransitions.howStep2" t-html></li>
+      <li t="docs.routing.viewTransitions.howStep3" t-html></li>
+      <li t="docs.routing.viewTransitions.howStep4" t-html></li>
+    </ol>
+
+    <!-- Deprecation -->
+    <h3 class="doc-subtitle" t="docs.routing.viewTransitions.deprecationTitle"></h3>
+    <p class="doc-text" t="docs.routing.viewTransitions.deprecationText" t-html></p>
+    <div class="callout">
+      <p t="docs.routing.viewTransitions.deprecationCallout" t-html></p>
+    </div>
+    <div class="code-block"><pre><span class="hl-cmt">&lt;!-- Old approach (still works with viewTransition: false) --&gt;</span>
+<span class="hl-tag">&lt;main</span> <span class="hl-attr">route-view</span> <span class="hl-attr">transition</span>=<span class="hl-str">"fade"</span><span class="hl-tag">&gt;&lt;/main&gt;</span>
+<span class="hl-cmt">&lt;!-- + manual CSS: .fade-enter, .fade-enter-active, .fade-leave, ... --&gt;</span>
+
+<span class="hl-cmt">&lt;!-- New approach (default, no extra CSS needed for presets) --&gt;</span>
+<span class="hl-tag">&lt;main</span> <span class="hl-attr">route-view</span> <span class="hl-attr">transition</span>=<span class="hl-str">"fade"</span><span class="hl-tag">&gt;&lt;/main&gt;</span>
+<span class="hl-cmt">&lt;!-- Works out of the box — uses View Transition API --&gt;</span></pre></div>
+  </div>
+
 </div>
 


### PR DESCRIPTION
## Summary

- Added a comprehensive **View Transitions** section to the routing docs (`routing.tpl`) covering built-in presets (slide, fade, scale, none), configuration (`router.viewTransition`), custom CSS via `::view-transition-*` pseudo-elements, how-it-works steps, and migration/deprecation guidance
- Added a callout note in the animations docs (`animations.tpl`) clarifying that `transition` on `route-view` now uses the View Transition API, while the class-based system still applies to regular elements
- Updated the cheatsheet (`cheatsheet.tpl`) with new entries for View Transition API presets in both the routing and animation tables
- Added all i18n keys across 5 locales (en, pt, es, fr, it) keeping technical terms in English per project convention

## Files Changed

- `docs/templates/docs/routing.tpl` — New "View Transitions" section
- `docs/templates/docs/animations.tpl` — Added VT API callout note
- `docs/templates/docs/cheatsheet.tpl` — Added VT API entries to routing and animation tables
- `docs/locales/en/docs.json` — English i18n keys
- `docs/locales/pt/docs.json` — Portuguese i18n keys
- `docs/locales/es/docs.json` — Spanish i18n keys
- `docs/locales/fr/docs.json` — French i18n keys
- `docs/locales/it/docs.json` — Italian i18n keys

## Test Plan

- [ ] Verify routing docs page renders the View Transitions section correctly at `/docs/routing#view-transitions`
- [ ] Verify animations docs page shows the callout note linking to routing docs
- [ ] Verify cheatsheet shows the new VT API rows in both routing and animation tables
- [ ] Test all 5 locales render without missing translation keys
- [ ] Verify all JSON locale files parse without errors