### PR TITLE
NOJS-23: Update prefetch to understand layout routes

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -769,15 +769,40 @@ export function _createRouter() {
       for (const [path, lazy] of routeLazy) {
         if (lazy === "ondemand" || path === current.path || path === "*") continue;
         const segment = path === "/" ? indexName : path.replace(/^\//, "");
+        const pathSegments = path === "/" ? [] : path.replace(/^\//, "").split("/").filter(Boolean);
+
+        // ── NOJS-23: Layout-aware prefetch for multi-segment routes ───────
+        // When we know a segment is a layout (cached by _resolveHierarchicalTemplate
+        // or _resolveNestedOutlets), prefetch BOTH the layout template and the
+        // child template instead of only the flat path.
+        if (pathSegments.length > 1) {
+          const firstSegment = pathSegments[0];
+          const layoutCacheKey = outletName + ":layout:" + baseSrc + firstSegment + ext;
+          const layoutCached = _autoTemplateCache.get(layoutCacheKey);
+
+          if (layoutCached && !layoutCached.__loadFailed) {
+            // Layout is known — prefetch the child template (e.g. docs/loops.tpl)
+            const childSegment = pathSegments.join("/");
+            const childTpl = _getOrCreateAutoTemplate(baseSrc, childSegment, ext, outletName, path);
+            if (!childTpl.__srcLoaded) {
+              _log("[ROUTER] Prefetch (layout child):", path, "→", baseSrc + childSegment + ext, lazy === "priority" ? "(priority)" : "(background)");
+              if (outletEl.hasAttribute("i18n-ns")) {
+                childTpl.setAttribute("i18n-ns", childSegment);
+              }
+              if (lazy === "priority") priorityFetches.push(childTpl);
+              else backgroundFetches.push(childTpl);
+            }
+            // Layout itself is already cached/loaded — no need to prefetch it again
+            continue;
+          }
+        }
+
+        // ── Flat path prefetch (original behavior) ────────────────────────
         const fullSrc = baseSrc + segment + ext;
         const cacheKey = outletName + ":" + fullSrc;
         if (_autoTemplateCache.has(cacheKey)) continue;
 
-        const tpl = document.createElement("template");
-        tpl.setAttribute("src", fullSrc);
-        tpl.setAttribute("route", path);
-        document.body.appendChild(tpl);
-        _autoTemplateCache.set(cacheKey, tpl);
+        const tpl = _getOrCreateAutoTemplate(baseSrc, segment, ext, outletName, path);
         _log("[ROUTER] Prefetch:", path, "→", fullSrc, lazy === "priority" ? "(priority)" : "(background)");
 
         if (outletEl.hasAttribute("i18n-ns")) {


### PR DESCRIPTION
## Summary

- Update `_prefetchRoutes` in `src/router.js` to be layout-aware for multi-segment routes
- For routes like `/docs/loops` where `docs.tpl` is a known layout (cached by NOJS-21's `_resolveHierarchicalTemplate`), prefetch only the child template (`docs/loops.tpl`) since the layout is already cached
- Refactor flat-path prefetch to reuse `_getOrCreateAutoTemplate`, removing duplicated template creation logic
- No new network requests for layout discovery — relies entirely on cached layout info from `_autoTemplateCache`

## How it works

1. When prefetching a multi-segment path (e.g. `/docs/loops`), checks `_autoTemplateCache` for a layout cache key (`outletName + ":layout:" + baseSrc + firstSegment + ext`)
2. If a layout is known and not failed, uses `_getOrCreateAutoTemplate` to prefetch the child template and skips re-fetching the layout
3. If no layout is known, falls back to the original flat-path prefetch behavior

## Test plan

- [ ] Navigate to a single-segment route (e.g. `/about`) — prefetch should work as before (flat path)
- [ ] Navigate to a multi-segment route (e.g. `/docs/loops`) after visiting `/docs/getting-started` — child templates for sibling routes should be prefetched using the known layout
- [ ] Verify no duplicate network requests for layout templates that are already cached
- [ ] Verify `lazy="ondemand"` routes are still excluded from prefetch
- [ ] Verify `lazy="priority"` routes are still fetched before background routes