### PR TITLE
NOJS-26: E2E tests for docs nested routing

### DIFF
--- a/e2e/examples/nested-routing-templates/docs/getting-started.tpl
+++ b/e2e/examples/nested-routing-templates/docs/getting-started.tpl
@@ -1,0 +1,4 @@
+<div data-test="doc-getting-started">
+  <h2>Getting Started</h2>
+  <p>Welcome to No.JS — an HTML-first reactive framework.</p>
+</div>

--- a/e2e/examples/nested-routing-templates/docs/loops.tpl
+++ b/e2e/examples/nested-routing-templates/docs/loops.tpl
@@ -1,0 +1,4 @@
+<div data-test="doc-loops">
+  <h2>Loops</h2>
+  <p>Use the each directive to iterate over arrays and objects.</p>
+</div>

--- a/e2e/examples/nested-routing-templates/docs/state.tpl
+++ b/e2e/examples/nested-routing-templates/docs/state.tpl
@@ -1,0 +1,4 @@
+<div data-test="doc-state">
+  <h2>State Management</h2>
+  <p>Manage reactive state with the state attribute.</p>
+</div>

--- a/e2e/examples/nested-routing-templates/home.tpl
+++ b/e2e/examples/nested-routing-templates/home.tpl
@@ -1,0 +1,4 @@
+<div data-test="page-home">
+  <h2>Home Page</h2>
+  <p>Welcome to the home page</p>
+</div>

--- a/e2e/examples/nested-routing.html
+++ b/e2e/examples/nested-routing.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Nested Routing — NoJS E2E</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; }
+    body { font-family: sans-serif; margin: 2rem; color: #333; }
+    nav a { margin-right: 1rem; text-decoration: none; color: #333; }
+    nav a.active { color: #2196f3; font-weight: 600; }
+    .docs-layout { display: flex; gap: 2rem; }
+    .docs-sidebar { min-width: 180px; border-right: 1px solid #ddd; padding-right: 1rem; }
+    .docs-sidebar ul { list-style: none; padding: 0; }
+    .docs-sidebar li { margin-bottom: 0.5rem; }
+    .docs-sidebar a { display: block; padding: 0.25rem 0; }
+    .docs-content { flex: 1; }
+  </style>
+</head>
+<body>
+
+  <!-- Top-level navigation -->
+  <header data-test="main-nav">
+    <nav>
+      <a route="/" route-active-exact="active" data-test="nav-home">Home</a>
+      <a route="/docs" route-active="active" data-test="nav-docs">Docs</a>
+    </nav>
+  </header>
+
+  <!-- Main route outlet (file-based) -->
+  <main route-view src="./nested-routing-templates/" route-index="home" data-test="main-outlet"></main>
+
+  <!-- Docs layout: sidebar + named outlet (lives in static HTML) -->
+  <div class="docs-layout" data-test="docs-layout-wrapper">
+    <nav class="docs-sidebar" data-test="docs-sidebar">
+      <h3>Documentation</h3>
+      <ul>
+        <li><a route="/docs/getting-started" route-active="active" data-test="sidebar-getting-started">Getting Started</a></li>
+        <li><a route="/docs/loops" route-active="active" data-test="sidebar-loops">Loops</a></li>
+        <li><a route="/docs/state" route-active="active" data-test="sidebar-state">State</a></li>
+      </ul>
+    </nav>
+    <div class="docs-content" route-view="docs" data-test="docs-outlet"></div>
+  </div>
+
+  <!-- Route templates: /home resolves via file-based (nested-routing-templates/home.tpl) -->
+
+  <!-- /docs → redirect to /docs/getting-started -->
+  <template route="/docs" guard="false" redirect="/docs/getting-started"></template>
+
+  <!-- Docs sub-routes: default outlet gets empty template, "docs" outlet gets the .tpl -->
+  <template route="/docs/getting-started"></template>
+  <template route="/docs/getting-started" outlet="docs" src="./nested-routing-templates/docs/getting-started.tpl"></template>
+
+  <template route="/docs/loops"></template>
+  <template route="/docs/loops" outlet="docs" src="./nested-routing-templates/docs/loops.tpl"></template>
+
+  <template route="/docs/state"></template>
+  <template route="/docs/state" outlet="docs" src="./nested-routing-templates/docs/state.tpl"></template>
+
+  <script src="../../dist/iife/no.js"></script>
+  <script>
+    NoJS.config({ router: { useHash: true, suppressHashWarning: true } });
+    NoJS.init();
+  </script>
+</body>
+</html>

--- a/e2e/tests/nested-routing.spec.ts
+++ b/e2e/tests/nested-routing.spec.ts
@@ -1,0 +1,164 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Nested Routing', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/e2e/examples/nested-routing.html');
+  });
+
+  test('1 — Navigate to /#/docs loads docs layout with sidebar and default child (getting-started)', async ({ page }) => {
+    await page.getByTestId('nav-docs').click();
+
+    // Sidebar should be visible
+    const sidebar = page.getByTestId('docs-sidebar');
+    await expect(sidebar).toBeVisible();
+
+    // Default child (getting-started) should be loaded in the docs outlet
+    const gettingStarted = page.getByTestId('doc-getting-started');
+    await expect(gettingStarted).toBeVisible();
+    await expect(gettingStarted).toContainText('Welcome to No.JS');
+
+    // Home page should NOT be visible in the main outlet
+    await expect(page.getByTestId('page-home')).toBeHidden();
+  });
+
+  test('2 — Click sidebar link to /#/docs/loops swaps child content, sidebar persists', async ({ page }) => {
+    // First navigate to docs
+    await page.getByTestId('nav-docs').click();
+    await expect(page.getByTestId('doc-getting-started')).toBeVisible();
+
+    // Click loops in sidebar
+    await page.getByTestId('sidebar-loops').click();
+
+    // Loops content should be visible
+    const loops = page.getByTestId('doc-loops');
+    await expect(loops).toBeVisible();
+    await expect(loops).toContainText('each directive');
+
+    // Sidebar should still be visible
+    await expect(page.getByTestId('docs-sidebar')).toBeVisible();
+
+    // Getting-started should no longer be visible
+    await expect(page.getByTestId('doc-getting-started')).toBeHidden();
+  });
+
+  test('3 — Click sidebar link to /#/docs/state swaps child again, layout stays', async ({ page }) => {
+    // Navigate to docs/loops first
+    await page.getByTestId('nav-docs').click();
+    await expect(page.getByTestId('doc-getting-started')).toBeVisible();
+
+    await page.getByTestId('sidebar-loops').click();
+    await expect(page.getByTestId('doc-loops')).toBeVisible();
+
+    // Now click state in sidebar
+    await page.getByTestId('sidebar-state').click();
+
+    // State content should be visible
+    const state = page.getByTestId('doc-state');
+    await expect(state).toBeVisible();
+    await expect(state).toContainText('reactive state');
+
+    // Sidebar should persist
+    await expect(page.getByTestId('docs-sidebar')).toBeVisible();
+
+    // Loops should be gone
+    await expect(page.getByTestId('doc-loops')).toBeHidden();
+  });
+
+  test('4 — Deep link directly to /#/docs/loops renders layout and correct child', async ({ page }) => {
+    // Navigate directly to docs/loops via URL
+    await page.goto('/e2e/examples/nested-routing.html#/docs/loops');
+
+    // Sidebar should be visible
+    await expect(page.getByTestId('docs-sidebar')).toBeVisible();
+
+    // Loops content should render in the docs outlet
+    const loops = page.getByTestId('doc-loops');
+    await expect(loops).toBeVisible();
+    await expect(loops).toContainText('each directive');
+
+    // Other doc pages should not be visible
+    await expect(page.getByTestId('doc-getting-started')).toBeHidden();
+    await expect(page.getByTestId('doc-state')).toBeHidden();
+  });
+
+  test('5 — Navigate from /#/docs/loops to /#/ (home) removes docs, shows home', async ({ page }) => {
+    // Start at docs/loops
+    await page.goto('/e2e/examples/nested-routing.html#/docs/loops');
+    await expect(page.getByTestId('doc-loops')).toBeVisible();
+
+    // Click home
+    await page.getByTestId('nav-home').click();
+
+    // Home page should be visible
+    const home = page.getByTestId('page-home');
+    await expect(home).toBeVisible();
+    await expect(home).toContainText('Welcome to the home page');
+
+    // Docs content should be cleared from the docs outlet
+    await expect(page.getByTestId('doc-loops')).toBeHidden();
+  });
+
+  test('6 — Navigate back to /#/docs from home re-renders layout with default child', async ({ page }) => {
+    // Start at home
+    await expect(page.getByTestId('page-home')).toBeVisible();
+
+    // Go to docs
+    await page.getByTestId('nav-docs').click();
+    await expect(page.getByTestId('doc-getting-started')).toBeVisible();
+
+    // Go back to home
+    await page.getByTestId('nav-home').click();
+    await expect(page.getByTestId('page-home')).toBeVisible();
+
+    // Go to docs again
+    await page.getByTestId('nav-docs').click();
+
+    // Docs layout should re-render with default child
+    await expect(page.getByTestId('docs-sidebar')).toBeVisible();
+    const gettingStarted = page.getByTestId('doc-getting-started');
+    await expect(gettingStarted).toBeVisible();
+    await expect(gettingStarted).toContainText('Welcome to No.JS');
+  });
+
+  test('7 — Single-segment route /#/home resolves via flat file-based routing', async ({ page }) => {
+    // Navigate to /home explicitly (not just /)
+    await page.goto('/e2e/examples/nested-routing.html#/home');
+
+    // The file-based router should resolve nested-routing-templates/home.tpl
+    const home = page.getByTestId('page-home');
+    await expect(home).toBeVisible();
+    await expect(home).toContainText('Welcome to the home page');
+  });
+
+  test('8 — Active class on sidebar links updates correctly', async ({ page }) => {
+    // Navigate to docs (redirects to getting-started)
+    await page.getByTestId('nav-docs').click();
+    await expect(page.getByTestId('doc-getting-started')).toBeVisible();
+
+    // Getting-started sidebar link should be active
+    await expect(page.getByTestId('sidebar-getting-started')).toHaveClass(/active/);
+    await expect(page.getByTestId('sidebar-loops')).not.toHaveClass(/active/);
+
+    // Click loops
+    await page.getByTestId('sidebar-loops').click();
+    await expect(page.getByTestId('doc-loops')).toBeVisible();
+
+    // Loops should now be active, getting-started should not
+    await expect(page.getByTestId('sidebar-loops')).toHaveClass(/active/);
+    await expect(page.getByTestId('sidebar-getting-started')).not.toHaveClass(/active/);
+  });
+
+  test('9 — Top-level nav active class reflects docs section', async ({ page }) => {
+    // Navigate to docs
+    await page.getByTestId('nav-docs').click();
+    await expect(page.getByTestId('doc-getting-started')).toBeVisible();
+
+    // The "Docs" nav link should be active (route-active prefix match)
+    await expect(page.getByTestId('nav-docs')).toHaveClass(/active/);
+    await expect(page.getByTestId('nav-home')).not.toHaveClass(/active/);
+
+    // Navigate to a specific doc sub-route — docs link should still be active
+    await page.getByTestId('sidebar-loops').click();
+    await expect(page.getByTestId('nav-docs')).toHaveClass(/active/);
+  });
+});


### PR DESCRIPTION
## Summary
- Add 9 Playwright E2E tests covering nested routing with named outlets, file-based routing, and sidebar persistence
- Create standalone `nested-routing.html` example with template files replicating the docs site's nested routing architecture
- Test cases: default child redirect, sidebar link navigation, child content swapping, deep linking, home/docs transitions, flat route resolution, and active class management

## Test plan
- [x] All 9 test cases pass on Chromium (verified locally)
- [ ] Verify tests pass on Firefox and WebKit in CI
- [ ] Confirm no regressions in existing routing tests

Generated with [Claude Code](https://claude.com/claude-code)