### PR TITLE
perf: Phase 1A — expression & context quick wins (NOJS-29)

### DIFF
--- a/src/context.js
+++ b/src/context.js
@@ -9,7 +9,7 @@ import { _devtoolsEmit, _ctxRegistry } from "./devtools.js";
 const _FORBIDDEN_CTX_KEYS = new Set(["__proto__", "constructor", "prototype"]);
 
 let _batchDepth = 0;
-const _batchQueue = new Set();
+let _batchQueue = new Set();
 let _ctxId = 0;
 let _ctxGeneration = 0;
 
@@ -24,8 +24,8 @@ export function _endBatch() {
   _batchDepth--;
   if (_batchDepth === 0 && _batchQueue.size > 0) {
     _devtoolsEmit("batch:end", { depth: 0, queueSize: _batchQueue.size });
-    const fns = [..._batchQueue];
-    _batchQueue.clear();
+    const fns = _batchQueue;
+    _batchQueue = new Set();
     fns.forEach((fn) => {
       if (fn._el && !fn._el.isConnected) return;
       fn();
@@ -113,13 +113,21 @@ export function createContext(data = {}, parent = null) {
       if (old !== value) {
         _ctxGeneration++;
         notify();
-        const isSensitive = typeof key === "string" && [..._SENSITIVE_KEYS].some(s => key.toLowerCase().includes(s));
-        _devtoolsEmit("ctx:updated", {
-          id: target.__devtoolsId,
-          key,
-          oldValue: isSensitive ? "[REDACTED]" : old,
-          newValue: isSensitive ? "[REDACTED]" : value,
-        });
+        if (_config.devtools) {
+          let isSensitive = false;
+          if (typeof key === "string") {
+            const lk = key.toLowerCase();
+            for (const s of _SENSITIVE_KEYS) {
+              if (lk.includes(s)) { isSensitive = true; break; }
+            }
+          }
+          _devtoolsEmit("ctx:updated", {
+            id: target.__devtoolsId,
+            key,
+            oldValue: isSensitive ? "[REDACTED]" : old,
+            newValue: isSensitive ? "[REDACTED]" : value,
+          });
+        }
       }
       return true;
     },

--- a/src/evaluate.js
+++ b/src/evaluate.js
@@ -1211,6 +1211,8 @@ function _execStmtNode(node, scope) {
 
 // Parse pipe syntax: "expr | filter1 | filter2:arg"
 function _parsePipes(exprStr) {
+  // Fast-path: ~90%+ expressions have zero pipes
+  if (!exprStr.includes('|')) return [exprStr.trim()];
   // Don't split on || (logical OR)
   const parts = [];
   let current = "";


### PR DESCRIPTION
## Summary
- **H2: Guard `_SENSITIVE_KEYS` behind devtools flag** — The `_SENSITIVE_KEYS` redaction check in `createContext()` set trap now only runs when `_config.devtools` is true. Inside the guard, iterates the Set directly with `for...of` (no spread to Array) and caches `key.toLowerCase()` in a local variable.
- **M1: `indexOf('|')` fast-path in `_parsePipes`** — Added `if (!exprStr.includes('|')) return [exprStr.trim()]` at the top, skipping the entire char-by-char loop for the ~90%+ of expressions that have zero pipes.
- **L5: Batch queue swap pattern** — Replaced `const fns = [..._batchQueue]; _batchQueue.clear()` with `const fns = _batchQueue; _batchQueue = new Set()`. No spread copy needed.

## Security invariants preserved
- `_SENSITIVE_KEYS` redaction remains fully active when `_config.devtools` is true
- `_FORBIDDEN_CTX_KEYS` check in set trap is untouched
- Expression error handling still catches and warns via `_warn()`

## Files changed
- `src/context.js` — devtools guard + batch queue swap
- `src/evaluate.js` — pipe fast-path

## Test plan
- [x] All 1418 Jest tests pass (0 failures, 3 skipped)