### PR TITLE
perf: Phase 1B — DOM, registry & fetch quick wins (NOJS-30)

### DIFF
--- a/src/dom.js
+++ b/src/dom.js
@@ -11,6 +11,9 @@ import { resolveUrl } from "./fetch.js";
 // Controlled by _config.templates.cache (default: true).
 export const _templateHtmlCache = new Map();
 
+// ─── DOMParser singleton — stateless, safe to reuse across calls ────────────
+const _domParser = new DOMParser();
+
 export function findContext(el) {
   let node = el;
   while (node) {
@@ -37,7 +40,7 @@ export function _cloneTemplate(id) {
 // Strip JS vectors from raw SVG markup using DOMParser for robust sanitization.
 // Regex-based approaches are bypassable via entity encoding and nested contexts.
 function _sanitizeSvgContent(svg) {
-  const doc = new DOMParser().parseFromString(svg, "image/svg+xml");
+  const doc = _domParser.parseFromString(svg, "image/svg+xml");
   const root = doc.documentElement;
   if (root.querySelector("parsererror") ||
       root.nodeName !== "svg" ||
@@ -99,7 +102,7 @@ export function _sanitizeHtml(html) {
   }
   if (typeof _config.sanitizeHtml === 'function') return _config.sanitizeHtml(html);
 
-  const doc = new DOMParser().parseFromString(html, 'text/html');
+  const doc = _domParser.parseFromString(html, 'text/html');
 
   function _clean(node) {
     for (const child of [...node.childNodes]) {

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -126,12 +126,15 @@ export async function _doFetch(
   }
 
   // ── Request interceptors ──
-  // Strip sensitive headers before passing to interceptors
+  // Strip sensitive headers before passing to interceptors (only when interceptors exist)
+  const hasRequestInterceptors = _interceptors.request.length > 0;
   const sensitiveHeaders = {};
-  for (const key of Object.keys(opts.headers)) {
-    if (_isSensitiveHeader(key)) {
-      sensitiveHeaders[key] = opts.headers[key];
-      delete opts.headers[key];
+  if (hasRequestInterceptors) {
+    for (const key of Object.keys(opts.headers)) {
+      if (_isSensitiveHeader(key)) {
+        sensitiveHeaders[key] = opts.headers[key];
+        delete opts.headers[key];
+      }
     }
   }
 
@@ -182,7 +185,9 @@ export async function _doFetch(
   }
 
   // Re-apply sensitive headers after interceptor chain
-  Object.assign(opts.headers, sensitiveHeaders);
+  if (hasRequestInterceptors) {
+    Object.assign(opts.headers, sensitiveHeaders);
+  }
 
   // Retry logic
   const maxRetries = retries !== undefined ? retries : (_config.retries || 0);

--- a/src/registry.js
+++ b/src/registry.js
@@ -26,15 +26,22 @@ export function _freezeDirectives() {
   _frozen = true;
 }
 
+// ─── Pattern-match prefixes for wildcard directives (hoisted, static) ────────
+const _MATCH_PATTERNS = Object.freeze([
+  { pattern: "class-*", prefix: "class-" },
+  { pattern: "on:*",    prefix: "on:" },
+  { pattern: "style-*", prefix: "style-" },
+  { pattern: "bind-*",  prefix: "bind-" },
+]);
+
 function _matchDirective(attrName) {
   if (_directives.has(attrName))
     return { directive: _directives.get(attrName), match: attrName };
   // Pattern matches
-  const patterns = ["class-*", "on:*", "style-*", "bind-*"];
-  for (const p of patterns) {
-    const prefix = p.replace("*", "");
-    if (attrName.startsWith(prefix) && _directives.has(p)) {
-      return { directive: _directives.get(p), match: p };
+  for (let i = 0; i < _MATCH_PATTERNS.length; i++) {
+    const { pattern, prefix } = _MATCH_PATTERNS[i];
+    if (attrName.startsWith(prefix) && _directives.has(pattern)) {
+      return { directive: _directives.get(pattern), match: pattern };
     }
   }
   return null;
@@ -45,7 +52,9 @@ export function processElement(el) {
   el.__declared = true;
 
   const matched = [];
-  for (const attr of [...el.attributes]) {
+  const attrs = el.attributes;
+  for (let i = 0, len = attrs.length; i < len; i++) {
+    const attr = attrs[i];
     const m = _matchDirective(attr.name);
     if (m) {
       matched.push({


### PR DESCRIPTION
## Summary

- **M3 — DOMParser singleton** (`src/dom.js`): Replace per-call `new DOMParser()` with a module-level `_domParser` constant, reused in both `_sanitizeHtml` and `_sanitizeSvgContent`. DOMParser is stateless and safe to share.
- **M7 — Hoist pattern matching** (`src/registry.js`): Move `_matchDirective` wildcard patterns to a frozen module-scope `_MATCH_PATTERNS` array with pre-computed prefixes, eliminating per-call allocation and `replace("*","")` string work.
- **L7 — Indexed attribute loop** (`src/registry.js`): Replace `[...el.attributes]` spread in `processElement` with an indexed `for` loop. Safe because the scan loop only reads attributes; all `init()` calls happen afterward in a separate loop.
- **L9 — Skip header strip** (`src/fetch.js`): Guard header strip/restore with `_interceptors.request.length > 0` so fetches without interceptors skip the sensitive-header dance entirely. When interceptors ARE present, behavior is unchanged.

## Security invariants preserved
- `_sanitizeHtml` still uses DOMParser (just the singleton instance)
- `_BLOCKED_TAGS` checks untouched
- Header stripping still runs when interceptors exist

## Test plan
- [x] All 1418 Jest tests pass (0 failures, 3 skipped)
- [ ] E2E tests (Playwright)

Closes NOJS-30 Phase 1B