### PR TITLE
perf(bench): comprehensive performance benchmark suite (NOJS-32)

### DIFF
--- a/__benchmarks__/expr-bench.test.js
+++ b/__benchmarks__/expr-bench.test.js
@@ -1,0 +1,236 @@
+// ═══════════════════════════════════════════════════════════════════════════
+// evaluate.js — expression evaluation throughput benchmark
+//
+// Measures parse + evaluate speed across five complexity tiers:
+//   1. Simple property access:   `name`
+//   2. Nested path:              `user.address.city`
+//   3. Pipe chain:               `name | uppercase`
+//   4. Ternary:                  `active ? 'yes' : 'no'`
+//   5. Comparison:               `count > 5`
+//
+// Each expression is evaluated ITERATIONS times against a realistic context.
+// Reports: ops/sec, mean, median, p95, min, max per expression type.
+// ═══════════════════════════════════════════════════════════════════════════
+
+import { evaluate } from '../src/evaluate.js';
+import { createContext } from '../src/context.js';
+import { _exprCache, _stmtCache } from '../src/evaluate.js';
+
+// Filters must be loaded so pipe expressions work
+import '../src/filters.js';
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const ITERATIONS = 10000;
+const WARMUP = 500;
+
+const EXPRESSIONS = {
+  'simple property':  'name',
+  'nested path':      'user.address.city',
+  'pipe chain':       'name | uppercase',
+  'ternary':          "active ? 'yes' : 'no'",
+  'comparison':       'count > 5',
+};
+
+// ─── Context factory ──────────────────────────────────────────────────────────
+
+function makeContext() {
+  return createContext({
+    name: 'Alice',
+    active: true,
+    count: 10,
+    user: {
+      address: {
+        city: 'Portland',
+        state: 'OR',
+        zip: '97201',
+      },
+    },
+  });
+}
+
+// ─── Measurement helpers ──────────────────────────────────────────────────────
+
+function stats(times) {
+  const sorted = [...times].sort((a, b) => a - b);
+  const sum = sorted.reduce((a, b) => a + b, 0);
+  const mean = sum / sorted.length;
+  const median = sorted.length % 2 === 0
+    ? (sorted[sorted.length / 2 - 1] + sorted[sorted.length / 2]) / 2
+    : sorted[Math.floor(sorted.length / 2)];
+  const p95 = sorted[Math.floor(sorted.length * 0.95)];
+  const min = sorted[0];
+  const max = sorted[sorted.length - 1];
+  const totalMs = sum;
+  const opsSec = Math.round((sorted.length / totalMs) * 1000);
+  return { opsSec, mean, median, p95, min, max };
+}
+
+const fmt = {
+  us: (v) => (v * 1000).toFixed(2) + ' µs',
+  ops: (v) => v.toLocaleString() + ' ops/s',
+};
+
+// ─── Cold-cache vs warm-cache helper ──────────────────────────────────────────
+
+function clearCaches() {
+  // Expression and statement caches are LRU Maps — clear them for cold-cache runs
+  _exprCache.set('__clear__', null); // access internal map through public API
+  // Brute-force: evaluate a bunch of unique expressions to evict the ones we care about
+  const ctx = makeContext();
+  for (let i = 0; i < 600; i++) {
+    try { evaluate(`_flush_${i}`, ctx); } catch { /* ignore */ }
+  }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// SCENARIO 1 — Expression throughput (warm cache)
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('Benchmark: expression evaluation throughput (warm cache)', () => {
+  const results = [];
+
+  afterAll(() => {
+    console.log('\n╔══════════════════════════════════════════════════╗');
+    console.log('║  EXPRESSION THROUGHPUT — warm cache               ║');
+    console.log('╚══════════════════════════════════════════════════╝');
+    console.table(results);
+  });
+
+  for (const [label, expr] of Object.entries(EXPRESSIONS)) {
+    test(`[warm] ${label}: "${expr}"`, () => {
+      const ctx = makeContext();
+
+      // Warm-up: populate expression cache
+      for (let i = 0; i < WARMUP; i++) evaluate(expr, ctx);
+
+      // Measure individual iteration times
+      const times = [];
+      for (let i = 0; i < ITERATIONS; i++) {
+        const t0 = performance.now();
+        evaluate(expr, ctx);
+        const t1 = performance.now();
+        times.push(t1 - t0);
+      }
+
+      const s = stats(times);
+      results.push({
+        expression: label,
+        'ops/sec': fmt.ops(s.opsSec),
+        mean: fmt.us(s.mean),
+        median: fmt.us(s.median),
+        p95: fmt.us(s.p95),
+        min: fmt.us(s.min),
+        max: fmt.us(s.max),
+      });
+
+      // Sanity check: expression must return a defined value
+      const val = evaluate(expr, ctx);
+      expect(val).toBeDefined();
+    });
+  }
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// SCENARIO 2 — Cold-cache vs warm-cache comparison
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('Benchmark: cold-cache vs warm-cache parse+evaluate', () => {
+  const results = [];
+
+  afterAll(() => {
+    console.log('\n╔══════════════════════════════════════════════════╗');
+    console.log('║  COLD vs WARM CACHE comparison                   ║');
+    console.log('╚══════════════════════════════════════════════════╝');
+    console.table(results);
+  });
+
+  for (const [label, expr] of Object.entries(EXPRESSIONS)) {
+    test(`[cold/warm] ${label}: "${expr}"`, () => {
+      const ctx = makeContext();
+      const RUNS = 100;
+
+      // Cold-cache: flush then measure first evaluation
+      const coldTimes = [];
+      for (let r = 0; r < RUNS; r++) {
+        clearCaches();
+        const t0 = performance.now();
+        evaluate(expr, ctx);
+        const t1 = performance.now();
+        coldTimes.push(t1 - t0);
+      }
+
+      // Warm-cache: expression is already cached
+      const warmTimes = [];
+      evaluate(expr, ctx); // ensure cached
+      for (let r = 0; r < RUNS; r++) {
+        const t0 = performance.now();
+        evaluate(expr, ctx);
+        const t1 = performance.now();
+        warmTimes.push(t1 - t0);
+      }
+
+      const coldS = stats(coldTimes);
+      const warmS = stats(warmTimes);
+      results.push({
+        expression: label,
+        'cold mean': fmt.us(coldS.mean),
+        'warm mean': fmt.us(warmS.mean),
+        'speedup': (coldS.mean / Math.max(warmS.mean, 0.0001)).toFixed(1) + 'x',
+        'cold p95': fmt.us(coldS.p95),
+        'warm p95': fmt.us(warmS.p95),
+      });
+
+      expect(true).toBe(true);
+    });
+  }
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// SCENARIO 3 — Batch evaluation (multiple expressions per context)
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('Benchmark: batch evaluation — 5 expressions per context', () => {
+  const results = [];
+
+  afterAll(() => {
+    console.log('\n╔══════════════════════════════════════════════════╗');
+    console.log('║  BATCH EVALUATION — 5 expressions/context        ║');
+    console.log('╚══════════════════════════════════════════════════╝');
+    console.table(results);
+  });
+
+  const BATCH_SIZES = [100, 500, 1000, 5000, 10000];
+  const allExprs = Object.values(EXPRESSIONS);
+
+  for (const batchSize of BATCH_SIZES) {
+    test(`batch of ${batchSize} contexts × 5 expressions`, () => {
+      const ctx = makeContext();
+
+      // Warm up caches
+      for (const expr of allExprs) evaluate(expr, ctx);
+
+      const t0 = performance.now();
+      for (let i = 0; i < batchSize; i++) {
+        for (const expr of allExprs) {
+          evaluate(expr, ctx);
+        }
+      }
+      const t1 = performance.now();
+
+      const totalOps = batchSize * allExprs.length;
+      const totalMs = t1 - t0;
+      const opsSec = Math.round((totalOps / totalMs) * 1000);
+
+      results.push({
+        contexts: batchSize,
+        totalOps,
+        'total (ms)': totalMs.toFixed(2) + ' ms',
+        'ops/sec': opsSec.toLocaleString(),
+        'per-op': fmt.us(totalMs / totalOps),
+      });
+
+      expect(totalOps).toBe(batchSize * 5);
+    });
+  }
+});

--- a/__benchmarks__/init-bench.test.js
+++ b/__benchmarks__/init-bench.test.js
@@ -1,0 +1,348 @@
+// ═══════════════════════════════════════════════════════════════════════════
+// init — processTree timing benchmark
+//
+// Measures the cost of walking and processing a DOM tree with various
+// directive combinations. Uses jsdom (same as the test suite).
+//
+// DOM sizes: 10, 50, 200 elements with different directive densities:
+//   1. state-only:   each element has `state`
+//   2. state + bind: `state` parent + `bind-textContent` children
+//   3. mixed:        state, bind, if, each (realistic page)
+//   4. heavy:        state, bind, if, each, class-*, style-*, on:click
+//
+// Reports: mean, median, p95, min, max, heap delta per configuration.
+// ═══════════════════════════════════════════════════════════════════════════
+
+import { _stores } from '../src/globals.js';
+import { processTree } from '../src/registry.js';
+
+// Import all directive categories to ensure they're registered
+import '../src/filters.js';
+import '../src/directives/state.js';
+import '../src/directives/binding.js';
+import '../src/directives/conditionals.js';
+import '../src/directives/loops.js';
+import '../src/directives/styling.js';
+import '../src/directives/events.js';
+import '../src/directives/refs.js';
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const RUNS = 10;
+const SIZES = [10, 50, 200];
+
+// ─── Measurement helpers ──────────────────────────────────────────────────────
+
+function stats(times) {
+  const sorted = [...times].sort((a, b) => a - b);
+  const sum = sorted.reduce((a, b) => a + b, 0);
+  const mean = sum / sorted.length;
+  const median = sorted.length % 2 === 0
+    ? (sorted[sorted.length / 2 - 1] + sorted[sorted.length / 2]) / 2
+    : sorted[Math.floor(sorted.length / 2)];
+  const p95 = sorted[Math.floor(sorted.length * 0.95)];
+  const min = sorted[0];
+  const max = sorted[sorted.length - 1];
+  return { mean, median, p95, min, max };
+}
+
+const fmt = {
+  ms: (v) => v.toFixed(2) + ' ms',
+  kb: (v) => (v / 1024).toFixed(0) + ' KB',
+};
+
+function cleanup() {
+  document.body.innerHTML = '';
+  Object.keys(_stores).forEach((k) => delete _stores[k]);
+}
+
+// ─── DOM builders ─────────────────────────────────────────────────────────────
+
+/** Scenario A: state-only — each element is a `state` container */
+function buildStateOnly(count) {
+  cleanup();
+  const root = document.createElement('div');
+  for (let i = 0; i < count; i++) {
+    const el = document.createElement('div');
+    el.setAttribute('state', JSON.stringify({ [`val_${i}`]: i }));
+    root.appendChild(el);
+  }
+  document.body.appendChild(root);
+  return root;
+}
+
+/** Scenario B: state + bind — parent state, children bind */
+function buildStateBind(count) {
+  cleanup();
+  const root = document.createElement('div');
+  const state = document.createElement('div');
+  // Build a data object with all values
+  const data = {};
+  for (let i = 0; i < count; i++) data[`item_${i}`] = `value-${i}`;
+  state.setAttribute('state', JSON.stringify(data));
+  root.appendChild(state);
+
+  for (let i = 0; i < count; i++) {
+    const el = document.createElement('span');
+    el.setAttribute('bind-textContent', `item_${i}`);
+    state.appendChild(el);
+  }
+  document.body.appendChild(root);
+  return root;
+}
+
+/** Scenario C: mixed — state, bind, if, each (realistic) */
+function buildMixed(count) {
+  cleanup();
+  const root = document.createElement('div');
+
+  // Create groups of 5: 1 state parent + 1 bind + 1 if + 1 each container + 1 plain
+  const groups = Math.ceil(count / 5);
+  for (let g = 0; g < groups; g++) {
+    const state = document.createElement('div');
+    const items = Array.from({ length: 3 }, (_, i) => ({
+      id: g * 3 + i, name: `item-${g * 3 + i}`,
+    }));
+    state.setAttribute('state', JSON.stringify({
+      show: true, label: `group-${g}`, items,
+    }));
+    root.appendChild(state);
+
+    // bind child
+    const bindEl = document.createElement('span');
+    bindEl.setAttribute('bind-textContent', 'label');
+    state.appendChild(bindEl);
+
+    // if child
+    const ifEl = document.createElement('div');
+    ifEl.setAttribute('if', 'show');
+    ifEl.textContent = 'visible';
+    state.appendChild(ifEl);
+
+    // each container — needs a template
+    const tpl = document.createElement('template');
+    tpl.id = `tpl-mixed-${g}`;
+    tpl.innerHTML = '<span class="row"></span>';
+    document.body.appendChild(tpl);
+
+    const eachEl = document.createElement('div');
+    eachEl.setAttribute('each', 'item in items');
+    eachEl.setAttribute('template', `tpl-mixed-${g}`);
+    state.appendChild(eachEl);
+
+    // plain child
+    const plainEl = document.createElement('div');
+    plainEl.textContent = 'plain';
+    state.appendChild(plainEl);
+  }
+
+  document.body.appendChild(root);
+  return root;
+}
+
+/** Scenario D: heavy — state, bind, class-*, style-*, on:click */
+function buildHeavy(count) {
+  cleanup();
+  const root = document.createElement('div');
+  const state = document.createElement('div');
+  const data = { active: true, color: 'red', count: 0 };
+  state.setAttribute('state', JSON.stringify(data));
+  root.appendChild(state);
+
+  for (let i = 0; i < count; i++) {
+    const el = document.createElement('div');
+    el.setAttribute('bind-textContent', 'count');
+    el.setAttribute('class-active', 'active');
+    el.setAttribute('style-color', 'color');
+    el.setAttribute('on:click', 'count = count + 1');
+    state.appendChild(el);
+  }
+
+  document.body.appendChild(root);
+  return root;
+}
+
+// ─── Benchmark runner ─────────────────────────────────────────────────────────
+
+function benchmarkInit(buildFn, size, runs) {
+  const times = [];
+  const heaps = [];
+
+  for (let r = 0; r < runs + 1; r++) { // +1 for warm-up
+    const root = buildFn(size);
+    const h0 = process.memoryUsage().heapUsed;
+    const t0 = performance.now();
+    processTree(root);
+    const t1 = performance.now();
+    const h1 = process.memoryUsage().heapUsed;
+    if (r === 0) continue; // discard warm-up
+    times.push(t1 - t0);
+    heaps.push(h1 - h0);
+  }
+
+  const avg = (arr) => arr.reduce((a, b) => a + b, 0) / arr.length;
+  return { ...stats(times), avgHeap: avg(heaps) };
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// SCENARIO 1 — State-only init
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('Benchmark: processTree — state-only elements', () => {
+  const results = [];
+
+  afterAll(() => {
+    console.log('\n╔══════════════════════════════════════════════════╗');
+    console.log('║  INIT — state-only elements                      ║');
+    console.log('╚══════════════════════════════════════════════════╝');
+    console.table(results);
+  });
+
+  for (const size of SIZES) {
+    test(`${size} state elements`, () => {
+      const s = benchmarkInit(buildStateOnly, size, RUNS);
+      results.push({
+        elements: size,
+        mean: fmt.ms(s.mean),
+        median: fmt.ms(s.median),
+        p95: fmt.ms(s.p95),
+        min: fmt.ms(s.min),
+        max: fmt.ms(s.max),
+        'heap delta': fmt.kb(s.avgHeap),
+        'per-element': (s.mean / size * 1000).toFixed(2) + ' µs',
+      });
+      expect(true).toBe(true);
+    });
+  }
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// SCENARIO 2 — State + bind init
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('Benchmark: processTree — state + bind elements', () => {
+  const results = [];
+
+  afterAll(() => {
+    console.log('\n╔══════════════════════════════════════════════════╗');
+    console.log('║  INIT — state + bind elements                    ║');
+    console.log('╚══════════════════════════════════════════════════╝');
+    console.table(results);
+  });
+
+  for (const size of SIZES) {
+    test(`${size} bind elements`, () => {
+      const s = benchmarkInit(buildStateBind, size, RUNS);
+      results.push({
+        elements: size,
+        mean: fmt.ms(s.mean),
+        median: fmt.ms(s.median),
+        p95: fmt.ms(s.p95),
+        min: fmt.ms(s.min),
+        max: fmt.ms(s.max),
+        'heap delta': fmt.kb(s.avgHeap),
+        'per-element': (s.mean / size * 1000).toFixed(2) + ' µs',
+      });
+      expect(true).toBe(true);
+    });
+  }
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// SCENARIO 3 — Mixed directive init
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('Benchmark: processTree — mixed directives', () => {
+  const results = [];
+
+  afterAll(() => {
+    console.log('\n╔══════════════════════════════════════════════════╗');
+    console.log('║  INIT — mixed directives (state/bind/if/each)    ║');
+    console.log('╚══════════════════════════════════════════════════╝');
+    console.table(results);
+  });
+
+  for (const size of SIZES) {
+    test(`~${size} mixed elements`, () => {
+      const s = benchmarkInit(buildMixed, size, RUNS);
+      results.push({
+        elements: '~' + size,
+        mean: fmt.ms(s.mean),
+        median: fmt.ms(s.median),
+        p95: fmt.ms(s.p95),
+        min: fmt.ms(s.min),
+        max: fmt.ms(s.max),
+        'heap delta': fmt.kb(s.avgHeap),
+      });
+      expect(true).toBe(true);
+    });
+  }
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// SCENARIO 4 — Heavy directive init
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('Benchmark: processTree — heavy directives (bind/class/style/on)', () => {
+  const results = [];
+
+  afterAll(() => {
+    console.log('\n╔══════════════════════════════════════════════════╗');
+    console.log('║  INIT — heavy directives (bind/class/style/on)   ║');
+    console.log('╚══════════════════════════════════════════════════╝');
+    console.table(results);
+  });
+
+  for (const size of SIZES) {
+    test(`${size} heavy elements`, () => {
+      const s = benchmarkInit(buildHeavy, size, RUNS);
+      results.push({
+        elements: size,
+        mean: fmt.ms(s.mean),
+        median: fmt.ms(s.median),
+        p95: fmt.ms(s.p95),
+        min: fmt.ms(s.min),
+        max: fmt.ms(s.max),
+        'heap delta': fmt.kb(s.avgHeap),
+        'per-element': (s.mean / size * 1000).toFixed(2) + ' µs',
+      });
+      expect(true).toBe(true);
+    });
+  }
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// SCENARIO 5 — Scaling comparison across all scenarios
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('Benchmark: processTree — scaling comparison', () => {
+  const results = [];
+
+  afterAll(() => {
+    console.log('\n╔══════════════════════════════════════════════════╗');
+    console.log('║  INIT SCALING — all scenarios at 200 elements     ║');
+    console.log('╚══════════════════════════════════════════════════╝');
+    console.table(results);
+  });
+
+  const scenarios = [
+    { name: 'state-only', build: buildStateOnly },
+    { name: 'state+bind', build: buildStateBind },
+    { name: 'mixed',      build: buildMixed },
+    { name: 'heavy',      build: buildHeavy },
+  ];
+
+  for (const { name, build } of scenarios) {
+    test(`200 elements — ${name}`, () => {
+      const s = benchmarkInit(build, 200, RUNS);
+      results.push({
+        scenario: name,
+        mean: fmt.ms(s.mean),
+        median: fmt.ms(s.median),
+        p95: fmt.ms(s.p95),
+        'heap delta': fmt.kb(s.avgHeap),
+      });
+      expect(true).toBe(true);
+    });
+  }
+});

--- a/__benchmarks__/memory-bench.test.js
+++ b/__benchmarks__/memory-bench.test.js
@@ -1,0 +1,376 @@
+// ═══════════════════════════════════════════════════════════════════════════
+// memory — leak detection & profile benchmark
+//
+// Measures memory behavior across repeated create/dispose cycles to detect
+// leaks. Also profiles the expression cache at different sizes.
+//
+// Scenarios:
+//   1. Context create/dispose cycles — does memory stabilize?
+//   2. Expression cache at different sizes — memory footprint
+//   3. Watcher create/dispose cycles — Set cleanup verification
+//   4. Store create/delete cycles — object cleanup verification
+//
+// Uses process.memoryUsage() for Node.js heap tracking.
+// ═══════════════════════════════════════════════════════════════════════════
+
+import { createContext } from '../src/context.js';
+import { evaluate, _exprCache } from '../src/evaluate.js';
+import { _stores, _storeWatchers, _config } from '../src/globals.js';
+import { processTree } from '../src/registry.js';
+
+import '../src/filters.js';
+import '../src/directives/state.js';
+import '../src/directives/binding.js';
+import '../src/directives/conditionals.js';
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const CYCLES = 50;
+
+// ─── Measurement helpers ──────────────────────────────────────────────────────
+
+const fmt = {
+  kb: (v) => (v / 1024).toFixed(0) + ' KB',
+  mb: (v) => (v / (1024 * 1024)).toFixed(2) + ' MB',
+  ms: (v) => v.toFixed(2) + ' ms',
+};
+
+function forceGC() {
+  // In Node.js with --expose-gc, global.gc() is available.
+  // In Jest/jsdom, we do our best with allocation pressure.
+  if (typeof global.gc === 'function') {
+    global.gc();
+  }
+}
+
+function heapUsed() {
+  forceGC();
+  return process.memoryUsage().heapUsed;
+}
+
+function cleanup() {
+  document.body.innerHTML = '';
+  Object.keys(_stores).forEach((k) => delete _stores[k]);
+  _storeWatchers.clear();
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// SCENARIO 1 — Context create/dispose cycles
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('Benchmark: memory — context create/dispose cycles', () => {
+  const results = [];
+  const BATCH_SIZES = [100, 500, 1000];
+
+  afterAll(() => {
+    console.log('\n╔══════════════════════════════════════════════════╗');
+    console.log('║  MEMORY — context create/dispose cycles           ║');
+    console.log('╚══════════════════════════════════════════════════╝');
+    console.table(results);
+  });
+
+  for (const batchSize of BATCH_SIZES) {
+    test(`${CYCLES} cycles × ${batchSize} contexts`, () => {
+      const heapSnapshots = [];
+      const baseline = heapUsed();
+
+      for (let c = 0; c < CYCLES; c++) {
+        // Create batch
+        const contexts = [];
+        for (let i = 0; i < batchSize; i++) {
+          contexts.push(createContext({
+            id: i, name: `ctx-${i}`,
+            nested: { a: 1, b: [1, 2, 3] },
+          }));
+        }
+
+        // Simulate dispose: clear all watcher references
+        for (const ctx of contexts) {
+          ctx.__listeners.clear();
+        }
+        contexts.length = 0;
+
+        if (c % 10 === 9) {
+          heapSnapshots.push(heapUsed() - baseline);
+        }
+      }
+
+      const finalHeap = heapUsed() - baseline;
+      const peakHeap = Math.max(...heapSnapshots, finalHeap);
+      const trend = heapSnapshots.length >= 2
+        ? heapSnapshots[heapSnapshots.length - 1] - heapSnapshots[0]
+        : 0;
+
+      results.push({
+        'batch size': batchSize,
+        cycles: CYCLES,
+        'final heap delta': fmt.kb(finalHeap),
+        'peak heap delta': fmt.kb(peakHeap),
+        'trend (last-first)': fmt.kb(trend),
+        'trend direction': trend > 50 * 1024 ? 'GROWING' : 'STABLE',
+      });
+
+      // The heap should not grow unboundedly — trend should be reasonable
+      expect(typeof finalHeap).toBe('number');
+    });
+  }
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// SCENARIO 2 — Expression cache memory footprint
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('Benchmark: memory — expression cache size', () => {
+  const results = [];
+  const CACHE_SIZES = [100, 250, 500, 1000];
+
+  afterAll(() => {
+    console.log('\n╔══════════════════════════════════════════════════╗');
+    console.log('║  MEMORY — expression cache footprint              ║');
+    console.log('╚══════════════════════════════════════════════════╝');
+    console.table(results);
+  });
+
+  for (const cacheSize of CACHE_SIZES) {
+    test(`cache size = ${cacheSize}`, () => {
+      const originalSize = _config.exprCacheSize;
+      _config.exprCacheSize = cacheSize;
+
+      const ctx = createContext({
+        a: 1, b: 2, c: 'hello', d: true,
+        nested: { x: 10, y: 20 },
+      });
+
+      const h0 = heapUsed();
+      const t0 = performance.now();
+
+      // Fill the cache with unique expressions
+      for (let i = 0; i < cacheSize * 2; i++) {
+        // Generate unique expressions that exercise different AST paths
+        const exprs = [
+          `a + ${i}`,
+          `nested.x > ${i}`,
+          `c | uppercase`,
+          `d ? ${i} : 0`,
+        ];
+        evaluate(exprs[i % exprs.length].replace(/\d+$/, String(i)), ctx);
+      }
+
+      const t1 = performance.now();
+      const h1 = heapUsed();
+
+      // Cache should have been bounded to cacheSize
+      const cacheEntries = _exprCache.size;
+
+      results.push({
+        'max size': cacheSize,
+        'actual entries': cacheEntries,
+        'fill time': fmt.ms(t1 - t0),
+        'heap delta': fmt.kb(h1 - h0),
+        'per-entry': fmt.kb((h1 - h0) / Math.max(cacheEntries, 1)),
+        'bounded': cacheEntries <= cacheSize ? 'YES' : 'NO',
+      });
+
+      expect(cacheEntries).toBeLessThanOrEqual(cacheSize);
+
+      _config.exprCacheSize = originalSize;
+    });
+  }
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// SCENARIO 3 — Watcher create/dispose cycles
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('Benchmark: memory — watcher create/dispose cycles', () => {
+  const results = [];
+  const WATCHER_COUNTS = [50, 200, 500];
+
+  afterAll(() => {
+    console.log('\n╔══════════════════════════════════════════════════╗');
+    console.log('║  MEMORY — watcher create/dispose cycles           ║');
+    console.log('╚══════════════════════════════════════════════════╝');
+    console.table(results);
+  });
+
+  for (const watcherCount of WATCHER_COUNTS) {
+    test(`${CYCLES} cycles × ${watcherCount} watchers`, () => {
+      const heapSnapshots = [];
+      const baseline = heapUsed();
+
+      for (let c = 0; c < CYCLES; c++) {
+        const ctx = createContext({ value: 0 });
+        const unwatchers = [];
+
+        // Attach watchers
+        for (let w = 0; w < watcherCount; w++) {
+          const unwatch = ctx.$watch(() => {});
+          unwatchers.push(unwatch);
+        }
+
+        // Verify watchers are registered
+        expect(ctx.__listeners.size).toBe(watcherCount);
+
+        // Dispose all watchers
+        for (const unwatch of unwatchers) unwatch();
+        unwatchers.length = 0;
+
+        // Verify cleanup
+        expect(ctx.__listeners.size).toBe(0);
+
+        if (c % 10 === 9) {
+          heapSnapshots.push(heapUsed() - baseline);
+        }
+      }
+
+      const finalHeap = heapUsed() - baseline;
+      const trend = heapSnapshots.length >= 2
+        ? heapSnapshots[heapSnapshots.length - 1] - heapSnapshots[0]
+        : 0;
+
+      results.push({
+        watchers: watcherCount,
+        cycles: CYCLES,
+        'final heap delta': fmt.kb(finalHeap),
+        'trend (last-first)': fmt.kb(trend),
+        'trend direction': trend > 50 * 1024 ? 'GROWING' : 'STABLE',
+      });
+    });
+  }
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// SCENARIO 4 — DOM processTree + dispose cycles
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('Benchmark: memory — DOM processTree + dispose cycles', () => {
+  const results = [];
+  const ELEMENT_COUNTS = [20, 50, 100];
+
+  afterAll(() => {
+    console.log('\n╔══════════════════════════════════════════════════╗');
+    console.log('║  MEMORY — DOM processTree + dispose cycles        ║');
+    console.log('╚══════════════════════════════════════════════════╝');
+    console.table(results);
+  });
+
+  for (const elemCount of ELEMENT_COUNTS) {
+    test(`${CYCLES} cycles × ${elemCount} elements`, () => {
+      const heapSnapshots = [];
+      const baseline = heapUsed();
+
+      for (let c = 0; c < CYCLES; c++) {
+        cleanup();
+
+        // Build DOM
+        const root = document.createElement('div');
+        const state = document.createElement('div');
+        state.setAttribute('state', JSON.stringify({ active: true, label: 'test' }));
+        root.appendChild(state);
+
+        for (let i = 0; i < elemCount; i++) {
+          const el = document.createElement('span');
+          el.setAttribute('bind-textContent', 'label');
+          if (i % 3 === 0) el.setAttribute('if', 'active');
+          state.appendChild(el);
+        }
+
+        document.body.appendChild(root);
+        processTree(root);
+
+        // Dispose by clearing DOM (simulating what directives do)
+        document.body.innerHTML = '';
+
+        if (c % 10 === 9) {
+          heapSnapshots.push(heapUsed() - baseline);
+        }
+      }
+
+      cleanup();
+      const finalHeap = heapUsed() - baseline;
+      const trend = heapSnapshots.length >= 2
+        ? heapSnapshots[heapSnapshots.length - 1] - heapSnapshots[0]
+        : 0;
+
+      results.push({
+        elements: elemCount,
+        cycles: CYCLES,
+        'final heap delta': fmt.kb(finalHeap),
+        'trend (last-first)': fmt.kb(trend),
+        'trend direction': trend > 100 * 1024 ? 'GROWING' : 'STABLE',
+      });
+
+      expect(typeof finalHeap).toBe('number');
+    });
+  }
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// SCENARIO 5 — Store create/delete memory
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('Benchmark: memory — store create/delete cycles', () => {
+  const results = [];
+  const STORE_COUNTS = [10, 50, 100];
+
+  afterAll(() => {
+    console.log('\n╔══════════════════════════════════════════════════╗');
+    console.log('║  MEMORY — store create/delete cycles              ║');
+    console.log('╚══════════════════════════════════════════════════╝');
+    console.table(results);
+  });
+
+  for (const storeCount of STORE_COUNTS) {
+    test(`${CYCLES} cycles × ${storeCount} stores`, () => {
+      const heapSnapshots = [];
+      const baseline = heapUsed();
+
+      for (let c = 0; c < CYCLES; c++) {
+        // Create stores with data
+        for (let s = 0; s < storeCount; s++) {
+          _stores[`bench_${s}`] = {
+            items: Array.from({ length: 10 }, (_, i) => ({
+              id: i, name: `item-${i}`, active: true,
+            })),
+            metadata: { created: Date.now(), version: c },
+          };
+        }
+
+        // Add watchers
+        const fns = [];
+        for (let w = 0; w < storeCount; w++) {
+          const fn = () => {};
+          _storeWatchers.add(fn);
+          fns.push(fn);
+        }
+
+        // Delete stores and watchers
+        for (let s = 0; s < storeCount; s++) {
+          delete _stores[`bench_${s}`];
+        }
+        for (const fn of fns) {
+          _storeWatchers.delete(fn);
+        }
+
+        if (c % 10 === 9) {
+          heapSnapshots.push(heapUsed() - baseline);
+        }
+      }
+
+      const finalHeap = heapUsed() - baseline;
+      const trend = heapSnapshots.length >= 2
+        ? heapSnapshots[heapSnapshots.length - 1] - heapSnapshots[0]
+        : 0;
+
+      results.push({
+        stores: storeCount,
+        cycles: CYCLES,
+        'final heap delta': fmt.kb(finalHeap),
+        'trend (last-first)': fmt.kb(trend),
+        'trend direction': trend > 50 * 1024 ? 'GROWING' : 'STABLE',
+      });
+
+      expect(_storeWatchers.size).toBe(0);
+    });
+  }
+});

--- a/__benchmarks__/reactive-bench.test.js
+++ b/__benchmarks__/reactive-bench.test.js
@@ -1,0 +1,268 @@
+// ═══════════════════════════════════════════════════════════════════════════
+// context.js — reactive update latency benchmark
+//
+// Measures the time from setting a property on a reactive context until all
+// attached watchers have fired. Tests watcher fan-out scaling:
+//   1, 10, 50, 200 watchers on the same property.
+//
+// Also compares batch vs non-batch updates to quantify the coalescing benefit.
+//
+// Reports: mean, median, p95, min, max per watcher count.
+// ═══════════════════════════════════════════════════════════════════════════
+
+import { createContext, _startBatch, _endBatch } from '../src/context.js';
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const RUNS = 200;
+const WATCHER_COUNTS = [1, 10, 50, 200];
+
+// ─── Measurement helpers ──────────────────────────────────────────────────────
+
+function stats(times) {
+  const sorted = [...times].sort((a, b) => a - b);
+  const sum = sorted.reduce((a, b) => a + b, 0);
+  const mean = sum / sorted.length;
+  const median = sorted.length % 2 === 0
+    ? (sorted[sorted.length / 2 - 1] + sorted[sorted.length / 2]) / 2
+    : sorted[Math.floor(sorted.length / 2)];
+  const p95 = sorted[Math.floor(sorted.length * 0.95)];
+  const min = sorted[0];
+  const max = sorted[sorted.length - 1];
+  return { mean, median, p95, min, max };
+}
+
+const fmt = {
+  us: (v) => (v * 1000).toFixed(2) + ' µs',
+  ms: (v) => v.toFixed(3) + ' ms',
+};
+
+// ═══════════════════════════════════════════════════════════════════════════
+// SCENARIO 1 — Watcher fan-out scaling (non-batch)
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('Benchmark: reactive update latency — watcher fan-out', () => {
+  const results = [];
+
+  afterAll(() => {
+    console.log('\n╔══════════════════════════════════════════════════╗');
+    console.log('║  REACTIVE LATENCY — watcher fan-out (non-batch)  ║');
+    console.log('╚══════════════════════════════════════════════════╝');
+    console.table(results);
+  });
+
+  for (const count of WATCHER_COUNTS) {
+    test(`${count} watcher(s) — non-batch`, () => {
+      const times = [];
+
+      for (let r = 0; r < RUNS; r++) {
+        const ctx = createContext({ value: 0 });
+        let fired = 0;
+
+        // Attach watchers
+        for (let w = 0; w < count; w++) {
+          ctx.$watch(() => { fired++; });
+        }
+
+        fired = 0;
+        const t0 = performance.now();
+        ctx.value = r + 1;
+        const t1 = performance.now();
+
+        times.push(t1 - t0);
+        expect(fired).toBe(count);
+      }
+
+      const s = stats(times);
+      results.push({
+        watchers: count,
+        mean: fmt.us(s.mean),
+        median: fmt.us(s.median),
+        p95: fmt.us(s.p95),
+        min: fmt.us(s.min),
+        max: fmt.us(s.max),
+        'per-watcher': fmt.us(s.mean / count),
+      });
+    });
+  }
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// SCENARIO 2 — Batch vs non-batch comparison
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('Benchmark: batch vs non-batch update (50 watchers)', () => {
+  const results = [];
+  const WATCHER_COUNT = 50;
+  const UPDATES_PER_RUN = 10;
+
+  afterAll(() => {
+    console.log('\n╔══════════════════════════════════════════════════╗');
+    console.log('║  BATCH vs NON-BATCH — 50 watchers, 10 updates    ║');
+    console.log('╚══════════════════════════════════════════════════╝');
+    console.table(results);
+  });
+
+  test('non-batch: 10 sequential updates', () => {
+    const times = [];
+
+    for (let r = 0; r < RUNS; r++) {
+      const ctx = createContext({ value: 0 });
+      let fired = 0;
+
+      for (let w = 0; w < WATCHER_COUNT; w++) {
+        ctx.$watch(() => { fired++; });
+      }
+
+      fired = 0;
+      const t0 = performance.now();
+      for (let u = 0; u < UPDATES_PER_RUN; u++) {
+        ctx.value = u + 1;
+      }
+      const t1 = performance.now();
+
+      times.push(t1 - t0);
+      // Each update fires all watchers: 10 × 50 = 500
+      expect(fired).toBe(WATCHER_COUNT * UPDATES_PER_RUN);
+    }
+
+    const s = stats(times);
+    results.push({
+      mode: 'non-batch',
+      'watcher fires': WATCHER_COUNT * UPDATES_PER_RUN,
+      mean: fmt.us(s.mean),
+      median: fmt.us(s.median),
+      p95: fmt.us(s.p95),
+      min: fmt.us(s.min),
+      max: fmt.us(s.max),
+    });
+  });
+
+  test('batch: 10 updates coalesced', () => {
+    const times = [];
+
+    for (let r = 0; r < RUNS; r++) {
+      const ctx = createContext({ value: 0 });
+      let fired = 0;
+
+      for (let w = 0; w < WATCHER_COUNT; w++) {
+        ctx.$watch(() => { fired++; });
+      }
+
+      fired = 0;
+      const t0 = performance.now();
+      _startBatch();
+      for (let u = 0; u < UPDATES_PER_RUN; u++) {
+        ctx.value = u + 1;
+      }
+      _endBatch();
+      const t1 = performance.now();
+
+      times.push(t1 - t0);
+      // Batch coalesces: each watcher fires once = 50
+      expect(fired).toBe(WATCHER_COUNT);
+    }
+
+    const s = stats(times);
+    results.push({
+      mode: 'batch',
+      'watcher fires': WATCHER_COUNT,
+      mean: fmt.us(s.mean),
+      median: fmt.us(s.median),
+      p95: fmt.us(s.p95),
+      min: fmt.us(s.min),
+      max: fmt.us(s.max),
+    });
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// SCENARIO 3 — Context creation + disposal throughput
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('Benchmark: context creation throughput', () => {
+  const results = [];
+  const SIZES = [100, 500, 1000, 5000];
+
+  afterAll(() => {
+    console.log('\n╔══════════════════════════════════════════════════╗');
+    console.log('║  CONTEXT CREATION THROUGHPUT                      ║');
+    console.log('╚══════════════════════════════════════════════════╝');
+    console.table(results);
+  });
+
+  for (const count of SIZES) {
+    test(`create ${count} contexts`, () => {
+      const data = { name: 'test', value: 42, nested: { a: 1, b: 2 } };
+
+      const h0 = process.memoryUsage().heapUsed;
+      const t0 = performance.now();
+      const contexts = [];
+      for (let i = 0; i < count; i++) {
+        contexts.push(createContext({ ...data, id: i }));
+      }
+      const t1 = performance.now();
+      const h1 = process.memoryUsage().heapUsed;
+
+      const totalMs = t1 - t0;
+      const opsSec = Math.round((count / totalMs) * 1000);
+
+      results.push({
+        count,
+        'total (ms)': totalMs.toFixed(2) + ' ms',
+        'per-ctx': fmt.us(totalMs / count),
+        'ops/sec': opsSec.toLocaleString(),
+        'heap delta': ((h1 - h0) / 1024).toFixed(0) + ' KB',
+      });
+
+      expect(contexts.length).toBe(count);
+    });
+  }
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// SCENARIO 4 — Parent chain depth impact
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('Benchmark: parent chain depth — property resolution', () => {
+  const results = [];
+  const DEPTHS = [1, 5, 10, 20];
+
+  afterAll(() => {
+    console.log('\n╔══════════════════════════════════════════════════╗');
+    console.log('║  PARENT CHAIN — property resolution cost          ║');
+    console.log('╚══════════════════════════════════════════════════╝');
+    console.table(results);
+  });
+
+  for (const depth of DEPTHS) {
+    test(`chain depth ${depth}`, () => {
+      // Build a parent chain with the target property at the root
+      let root = createContext({ target: 'found', level: 0 });
+      let current = root;
+      for (let d = 1; d < depth; d++) {
+        current = createContext({ level: d }, current);
+      }
+
+      const times = [];
+      for (let r = 0; r < RUNS; r++) {
+        const t0 = performance.now();
+        // Access the property — it must walk up the chain
+        const val = current.target;
+        const t1 = performance.now();
+        times.push(t1 - t0);
+        expect(val).toBe('found');
+      }
+
+      const s = stats(times);
+      results.push({
+        depth,
+        mean: fmt.us(s.mean),
+        median: fmt.us(s.median),
+        p95: fmt.us(s.p95),
+        min: fmt.us(s.min),
+        max: fmt.us(s.max),
+      });
+    });
+  }
+});

--- a/__benchmarks__/store-bench.test.js
+++ b/__benchmarks__/store-bench.test.js
@@ -1,0 +1,296 @@
+// ═══════════════════════════════════════════════════════════════════════════
+// store — watcher scaling benchmark
+//
+// Measures store notification throughput at different watcher counts.
+// The store notification path is separate from context reactivity —
+// _notifyStoreWatchers iterates _storeWatchers (a global Set).
+//
+// Scenarios:
+//   1. Single store change with 10/50/200/500 watchers
+//   2. Multiple simultaneous store changes
+//   3. Watcher registration/deregistration throughput
+//
+// Reports: mean, median, p95, min, max per watcher count.
+// ═══════════════════════════════════════════════════════════════════════════
+
+import { _stores, _storeWatchers, _notifyStoreWatchers } from '../src/globals.js';
+import { createContext } from '../src/context.js';
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const RUNS = 200;
+const WATCHER_COUNTS = [10, 50, 200, 500];
+
+// ─── Measurement helpers ──────────────────────────────────────────────────────
+
+function stats(times) {
+  const sorted = [...times].sort((a, b) => a - b);
+  const sum = sorted.reduce((a, b) => a + b, 0);
+  const mean = sum / sorted.length;
+  const median = sorted.length % 2 === 0
+    ? (sorted[sorted.length / 2 - 1] + sorted[sorted.length / 2]) / 2
+    : sorted[Math.floor(sorted.length / 2)];
+  const p95 = sorted[Math.floor(sorted.length * 0.95)];
+  const min = sorted[0];
+  const max = sorted[sorted.length - 1];
+  return { mean, median, p95, min, max };
+}
+
+const fmt = {
+  us: (v) => (v * 1000).toFixed(2) + ' µs',
+  ms: (v) => v.toFixed(3) + ' ms',
+};
+
+// ─── Setup / teardown ─────────────────────────────────────────────────────────
+
+function cleanupStore() {
+  _storeWatchers.clear();
+  Object.keys(_stores).forEach((k) => delete _stores[k]);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// SCENARIO 1 — Store notification fan-out
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('Benchmark: store notification — watcher scaling', () => {
+  const results = [];
+
+  afterAll(() => {
+    console.log('\n╔══════════════════════════════════════════════════╗');
+    console.log('║  STORE NOTIFICATION — watcher fan-out             ║');
+    console.log('╚══════════════════════════════════════════════════╝');
+    console.table(results);
+  });
+
+  afterEach(() => cleanupStore());
+
+  for (const count of WATCHER_COUNTS) {
+    test(`${count} store watcher(s) — single notification`, () => {
+      const times = [];
+
+      for (let r = 0; r < RUNS; r++) {
+        cleanupStore();
+        _stores.counter = { value: 0 };
+        let fired = 0;
+
+        // Register watchers (simulating what _watchExpr does internally)
+        for (let w = 0; w < count; w++) {
+          const fn = () => { fired++; };
+          _storeWatchers.add(fn);
+        }
+
+        fired = 0;
+        const t0 = performance.now();
+        _notifyStoreWatchers();
+        const t1 = performance.now();
+
+        times.push(t1 - t0);
+        expect(fired).toBe(count);
+      }
+
+      const s = stats(times);
+      results.push({
+        watchers: count,
+        mean: fmt.us(s.mean),
+        median: fmt.us(s.median),
+        p95: fmt.us(s.p95),
+        min: fmt.us(s.min),
+        max: fmt.us(s.max),
+        'per-watcher': fmt.us(s.mean / count),
+      });
+    });
+  }
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// SCENARIO 2 — Multiple simultaneous store changes
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('Benchmark: multiple store changes — notification cost', () => {
+  const results = [];
+  const STORE_COUNTS = [1, 5, 10, 20];
+  const WATCHERS_PER_RUN = 50;
+
+  afterAll(() => {
+    console.log('\n╔══════════════════════════════════════════════════╗');
+    console.log('║  MULTIPLE STORE CHANGES — notification cost       ║');
+    console.log('╚══════════════════════════════════════════════════╝');
+    console.table(results);
+  });
+
+  afterEach(() => cleanupStore());
+
+  for (const storeCount of STORE_COUNTS) {
+    test(`${storeCount} store change(s) × ${WATCHERS_PER_RUN} watchers`, () => {
+      const times = [];
+
+      for (let r = 0; r < RUNS; r++) {
+        cleanupStore();
+
+        // Set up multiple stores
+        for (let s = 0; s < storeCount; s++) {
+          _stores[`store_${s}`] = { value: 0 };
+        }
+
+        let fired = 0;
+        for (let w = 0; w < WATCHERS_PER_RUN; w++) {
+          _storeWatchers.add(() => { fired++; });
+        }
+
+        // Simulate changing all stores and notifying once
+        fired = 0;
+        const t0 = performance.now();
+        for (let s = 0; s < storeCount; s++) {
+          _stores[`store_${s}`].value++;
+        }
+        _notifyStoreWatchers();
+        const t1 = performance.now();
+
+        times.push(t1 - t0);
+        expect(fired).toBe(WATCHERS_PER_RUN);
+      }
+
+      const s = stats(times);
+      results.push({
+        stores: storeCount,
+        watchers: WATCHERS_PER_RUN,
+        mean: fmt.us(s.mean),
+        median: fmt.us(s.median),
+        p95: fmt.us(s.p95),
+        min: fmt.us(s.min),
+        max: fmt.us(s.max),
+      });
+    });
+  }
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// SCENARIO 3 — Watcher registration/deregistration throughput
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('Benchmark: watcher registration/deregistration', () => {
+  const results = [];
+  const COUNTS = [100, 500, 1000, 5000];
+
+  afterAll(() => {
+    console.log('\n╔══════════════════════════════════════════════════╗');
+    console.log('║  WATCHER REGISTRATION/DEREGISTRATION throughput   ║');
+    console.log('╚══════════════════════════════════════════════════╝');
+    console.table(results);
+  });
+
+  afterEach(() => cleanupStore());
+
+  for (const count of COUNTS) {
+    test(`register + deregister ${count} watchers`, () => {
+      const regTimes = [];
+      const deregTimes = [];
+
+      for (let r = 0; r < 50; r++) {
+        cleanupStore();
+        const fns = [];
+
+        // Register
+        const t0 = performance.now();
+        for (let w = 0; w < count; w++) {
+          const fn = () => {};
+          fns.push(fn);
+          _storeWatchers.add(fn);
+        }
+        const t1 = performance.now();
+        regTimes.push(t1 - t0);
+
+        // Deregister
+        const t2 = performance.now();
+        for (const fn of fns) {
+          _storeWatchers.delete(fn);
+        }
+        const t3 = performance.now();
+        deregTimes.push(t3 - t2);
+
+        expect(_storeWatchers.size).toBe(0);
+      }
+
+      const regS = stats(regTimes);
+      const deregS = stats(deregTimes);
+      results.push({
+        count,
+        'reg mean': fmt.us(regS.mean),
+        'reg p95': fmt.us(regS.p95),
+        'dereg mean': fmt.us(deregS.mean),
+        'dereg p95': fmt.us(deregS.p95),
+      });
+    });
+  }
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// SCENARIO 4 — Store + context watcher interaction
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('Benchmark: context watchers + store watchers combined', () => {
+  const results = [];
+  const CONFIGS = [
+    { ctxWatchers: 10, storeWatchers: 10 },
+    { ctxWatchers: 50, storeWatchers: 50 },
+    { ctxWatchers: 100, storeWatchers: 100 },
+    { ctxWatchers: 200, storeWatchers: 200 },
+  ];
+
+  afterAll(() => {
+    console.log('\n╔══════════════════════════════════════════════════╗');
+    console.log('║  COMBINED — context + store watchers              ║');
+    console.log('╚══════════════════════════════════════════════════╝');
+    console.table(results);
+  });
+
+  afterEach(() => cleanupStore());
+
+  for (const cfg of CONFIGS) {
+    test(`${cfg.ctxWatchers} ctx + ${cfg.storeWatchers} store watchers`, () => {
+      const times = [];
+
+      for (let r = 0; r < RUNS; r++) {
+        cleanupStore();
+        _stores.data = { count: 0 };
+
+        const ctx = createContext({ value: 0 });
+        let ctxFired = 0;
+        let storeFired = 0;
+
+        for (let w = 0; w < cfg.ctxWatchers; w++) {
+          ctx.$watch(() => { ctxFired++; });
+        }
+        for (let w = 0; w < cfg.storeWatchers; w++) {
+          _storeWatchers.add(() => { storeFired++; });
+        }
+
+        ctxFired = 0;
+        storeFired = 0;
+
+        // Trigger both context and store notifications
+        const t0 = performance.now();
+        ctx.value = r + 1;
+        _stores.data.count++;
+        _notifyStoreWatchers();
+        const t1 = performance.now();
+
+        times.push(t1 - t0);
+        expect(ctxFired).toBe(cfg.ctxWatchers);
+        expect(storeFired).toBe(cfg.storeWatchers);
+      }
+
+      const s = stats(times);
+      results.push({
+        'ctx watchers': cfg.ctxWatchers,
+        'store watchers': cfg.storeWatchers,
+        total: cfg.ctxWatchers + cfg.storeWatchers,
+        mean: fmt.us(s.mean),
+        median: fmt.us(s.median),
+        p95: fmt.us(s.p95),
+        min: fmt.us(s.min),
+        max: fmt.us(s.max),
+      });
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- Add 5 new benchmark files to `__benchmarks__/` covering expression evaluation throughput, reactive update latency, store watcher scaling, DOM init timing, and memory profiling
- All benchmarks follow the existing Jest-based pattern with tabular output (mean, median, p95, min, max) for before/after comparison
- Existing loop benchmarks unchanged; all 6 suites pass (173 tests total)

## New benchmarks

| File | What it measures |
|------|-----------------|
| `expr-bench.test.js` | Expression parse+evaluate throughput across 5 complexity tiers; cold vs warm cache; batch evaluation scaling |
| `reactive-bench.test.js` | Context watcher fan-out (1/10/50/200 watchers); batch vs non-batch updates; context creation throughput; parent chain depth |
| `store-bench.test.js` | Store notification scaling (10/50/200/500 watchers); multi-store changes; watcher registration/deregistration; combined ctx+store watchers |
| `init-bench.test.js` | `processTree` timing at 10/50/200 elements with 4 directive density levels (state-only, state+bind, mixed, heavy) |
| `memory-bench.test.js` | Context create/dispose leak detection; expression cache footprint at different sizes; watcher/store lifecycle memory stability |

## Test plan
- [x] `npm run bench` runs all 6 suites without errors (173 tests pass)
- [x] Each new file runnable standalone via `npx jest --no-coverage __benchmarks__/<file>`
- [x] Output format matches existing benchmark tables