### PR TITLE
perf(router,evaluate): pre-compile route regexes + extract evalArgs (NOJS-36)

### DIFF
--- a/src/evaluate.js
+++ b/src/evaluate.js
@@ -891,6 +891,23 @@ function _wrapTimer(name) {
 const _safeTimers = {};
 for (const t of _TIMER_WRAPPERS) _safeTimers[t] = _wrapTimer(t);
 
+// Evaluate call arguments at module level to avoid per-call closure allocation.
+// Handles SpreadElement by iterating the spread result.
+function _evalArgs(args, scope) {
+  const result = [];
+  for (let i = 0; i < args.length; i++) {
+    if (args[i].type === 'SpreadElement') {
+      const spread = _evalNode(args[i].argument, scope);
+      if (spread && typeof spread[Symbol.iterator] === 'function') {
+        result.push(...spread);
+      }
+    } else {
+      result.push(_evalNode(args[i], scope));
+    }
+  }
+  return result;
+}
+
 function _evalNode(node, scope) {
   try {
     if (!node) return undefined;
@@ -1007,22 +1024,6 @@ function _evalNode(node, scope) {
 
       case 'CallExpr':
       case 'OptionalCallExpr': {
-        // Evaluate args (handle spread)
-        const evalArgs = (args) => {
-          const result = [];
-          for (let i = 0; i < args.length; i++) {
-            if (args[i].type === 'SpreadElement') {
-              const spread = _evalNode(args[i].argument, scope);
-              if (spread && typeof spread[Symbol.iterator] === 'function') {
-                result.push(...spread);
-              }
-            } else {
-              result.push(_evalNode(args[i], scope));
-            }
-          }
-          return result;
-        };
-
         if (node.callee.type === 'MemberExpr' || node.callee.type === 'OptionalMemberExpr') {
           const thisObj = _evalNode(node.callee.object, scope);
           if (thisObj == null) {
@@ -1035,7 +1036,7 @@ function _evalNode(node, scope) {
           if (_FORBIDDEN_PROPS[prop]) return undefined;
           const fn = thisObj[prop];
           if (typeof fn !== 'function') return undefined;
-          const callResult = fn.apply(thisObj, evalArgs(node.args));
+          const callResult = fn.apply(thisObj, _evalArgs(node.args, scope));
           if (callResult instanceof Document || callResult === globalThis.document) return _safeDocument;
           if (callResult === globalThis.window || callResult === globalThis) return _safeWindow;
           return callResult;
@@ -1044,7 +1045,7 @@ function _evalNode(node, scope) {
         const fn = _evalNode(node.callee, scope);
         if (fn == null && node.type === 'OptionalCallExpr') return undefined;
         if (typeof fn !== 'function') return undefined;
-        const standaloneResult = fn.apply(undefined, evalArgs(node.args));
+        const standaloneResult = fn.apply(undefined, _evalArgs(node.args, scope));
         if (standaloneResult instanceof Document || standaloneResult === globalThis.document) return _safeDocument;
         if (standaloneResult === globalThis.window || standaloneResult === globalThis) return _safeWindow;
         return standaloneResult;

--- a/src/router.js
+++ b/src/router.js
@@ -73,7 +73,15 @@ export function _createRouter() {
   function _getOrCreateEntry(path) {
     let entry = routes.find((r) => r.path === path);
     if (!entry) {
-      entry = { path, outlets: {} };
+      // Pre-compile regex and extract param names at registration time
+      // so matchRoute() doesn't rebuild them on every navigation.
+      const paramNames = [];
+      const pattern = path.replace(/:(\w+)/g, (_, name) => {
+        paramNames.push(name);
+        return "([^/]+)";
+      });
+      const regex = new RegExp("^" + pattern + "$");
+      entry = { path, outlets: {}, regex, paramNames };
       routes.push(entry);
     }
     return entry;
@@ -89,18 +97,13 @@ export function _createRouter() {
 
   function matchRoute(path) {
     for (const route of routes) {
-      const paramNames = [];
-      const pattern = route.path.replace(/:(\w+)/g, (_, name) => {
-        paramNames.push(name);
-        return "([^/]+)";
-      });
-      const regex = new RegExp("^" + pattern + "$");
-      const match = path.match(regex);
+      const match = path.match(route.regex);
       if (match) {
         const params = {};
-        paramNames.forEach((name, i) => {
-          params[name] = match[i + 1];
-        });
+        const paramNames = route.paramNames;
+        for (let i = 0; i < paramNames.length; i++) {
+          params[paramNames[i]] = match[i + 1];
+        }
         return { route, params };
       }
     }


### PR DESCRIPTION
## Summary
- **M5 — Pre-compile route regexes:** Moved regex compilation and param name extraction from `matchRoute()` (called per navigation) to `_getOrCreateEntry()` (called once at registration). Each route entry now stores `{ regex, paramNames }` so `matchRoute()` only runs `path.match(route.regex)` without rebuilding the pattern.
- **L1 — Extract evalArgs to module level:** Extracted the `evalArgs` closure from the `CallExpr`/`OptionalCallExpr` case in `_evalNode()` to a standalone `_evalArgs(args, scope)` function. Eliminates a closure allocation on every function-call expression evaluation.

## Test plan
- [x] Full Jest suite passes (1470/1470, 3 skipped)
- [x] Router tests pass — parametric routes, wildcards, guards all exercised
- [x] Expression evaluator tests pass — function calls, spread args, optional chaining