### PR TITLE
perf(globals): remove per-element MutationObserver (NOJS-34)

### DIFF
--- a/__tests__/core.test.js
+++ b/__tests__/core.test.js
@@ -204,7 +204,7 @@ test('_cache is a Map', () => {
       expect(_storeWatchers.has(fn)).toBe(false);
     });
 
-    test('removes $store watcher from Set when element is removed without dispose', async () => {
+    test('prunes $store watcher lazily via isConnected guard when element is removed without dispose', () => {
       const ctx = createContext({});
       const fn = jest.fn();
 
@@ -222,13 +222,18 @@ test('_cache is a Map', () => {
       // Remove element externally (bypassing framework dispose)
       parent.innerHTML = '';
 
-      // Allow MutationObserver microtask to run
-      await new Promise((r) => setTimeout(r, 0));
+      // Watcher is still in the Set (no MutationObserver to eagerly remove it)
+      expect(_storeWatchers.has(fn)).toBe(true);
+
+      // _notifyStoreWatchers prunes disconnected elements via isConnected guard
+      _notifyStoreWatchers();
 
       expect(_storeWatchers.has(fn)).toBe(false);
+      // The watcher callback should NOT have been invoked for the disconnected element
+      expect(fn).not.toHaveBeenCalled();
     });
 
-    test('disconnects MutationObserver via _onDispose when _disposeTree runs (each re-render pattern)', () => {
+    test('removes $store watcher via _onDispose when _disposeTree runs (each re-render pattern)', () => {
       const ctx = createContext({});
       const fn = jest.fn();
 
@@ -248,7 +253,7 @@ test('_cache is a Map', () => {
       _disposeTree(itemWrapper);
       container.innerHTML = '';
 
-      // Watcher must be removed by the _onDispose path (not the MutationObserver callback)
+      // Watcher must be removed by the _onDispose path
       expect(_storeWatchers.has(fn)).toBe(false);
     });
 

--- a/src/globals.js
+++ b/src/globals.js
@@ -98,21 +98,6 @@ export function _watchExpr(expr, ctx, fn) {
   if (typeof expr === "string" && expr.includes("$store")) {
     _storeWatchers.add(fn);
     fn._el = _currentEl;
-    // Self-cleanup when the element is removed without going through dispose
-    const el = _currentEl;
-    if (el && el.parentElement) {
-      const ro = new MutationObserver(() => {
-        if (!el.isConnected) {
-          _storeWatchers.delete(fn);
-          unwatch();
-          ro.disconnect();
-        }
-      });
-      // subtree: false — we only care about direct children of parentElement being removed
-      ro.observe(el.parentElement, { childList: true, subtree: false });
-      // Also disconnect via the normal disposal path to avoid a dangling MO
-      _onDispose(() => ro.disconnect());
-    }
   }
 }
 


### PR DESCRIPTION
## Summary
- Remove per-element MutationObserver fallback from `_watchExpr()` in `src/globals.js`
- 50 store-bound elements previously created 50 individual MutationObservers with callbacks that fired redundantly
- The `isConnected` guard in `_notifyStoreWatchers()` already prunes disconnected elements lazily, making the per-element observers unnecessary
- Updated test in `core.test.js` to verify the lazy pruning behavior via `_notifyStoreWatchers()` instead of expecting eager MO-based cleanup

## Test plan
- [x] Full Jest suite passes: 1470 tests, 0 failures
- [x] Store watcher registration and `_onDispose` cleanup still works (test: "removes via _onDispose")
- [x] Disconnected elements are pruned lazily by `_notifyStoreWatchers()` (test: "prunes lazily via isConnected guard")
- [x] No-parent-element edge case still handled without throwing