### PR TITLE
perf(context,loops): optimize proxy get trap + reusable filter context (NOJS-35)

### DIFF
--- a/src/context.js
+++ b/src/context.js
@@ -60,48 +60,76 @@ export function createContext(data = {}, parent = null) {
     }
   }
 
+  // Pre-build $set closure outside the handler for reuse across all get() calls
+  const $setFn = (k, v) => {
+    const parts = k.split(".");
+    if (parts.some(p => _FORBIDDEN_CTX_KEYS.has(p))) return;
+    if (parts.length === 1) {
+      proxy[k] = v;
+    } else {
+      let obj = proxy;
+      for (let i = 0; i < parts.length - 1; i++) {
+        obj = obj[parts[i]];
+        if (obj == null) return;
+      }
+      const lastKey = parts[parts.length - 1];
+      const old = obj[lastKey];
+      obj[lastKey] = v;
+      if (old !== v) notify();
+    }
+  };
+
+  const $watchFn = (fn) => {
+    if (_currentEl) fn._el = _currentEl;
+    listeners.add(fn);
+    return () => listeners.delete(fn);
+  };
+
   const handler = {
     get(target, key) {
-      if (key === "__isProxy") return true;
-      if (key === "__raw") return target;
-      if (key === "__listeners") return listeners;
-      if (key === "$watch")
-        return (fn) => {
-          if (_currentEl) fn._el = _currentEl;
-          listeners.add(fn);
-          return () => listeners.delete(fn);
-        };
-      if (key === "$notify") return notify;
-      if (key === "$set")
-        return (k, v) => {
-          const parts = k.split(".");
-          if (parts.some(p => _FORBIDDEN_CTX_KEYS.has(p))) return;
-          if (parts.length === 1) {
-            proxy[k] = v;
-          } else {
-            let obj = proxy;
-            for (let i = 0; i < parts.length - 1; i++) {
-              obj = obj[parts[i]];
-              if (obj == null) return;
-            }
-            const lastKey = parts[parts.length - 1];
-            const old = obj[lastKey];
-            obj[lastKey] = v;
-            if (old !== v) notify();
-          }
-        };
-      if (key === "$parent") return parent;
-      if (key === "$refs") return _refs;
-      if (key === "$store") return _stores;
-      if (key === "$route")
-        return _routerInstance ? _routerInstance.current : {};
-      if (key === "$router") return _routerInstance;
-      if (key === "$i18n") return _i18n;
-      if (key === "$form") return target.$form || null;
-      // Plugin globals fallback (after all core $ checks)
-      if (key.startsWith("$") && key.slice(1) in _globals) {
-        return _globals[key.slice(1)];
+      // Fast path: non-string keys (Symbols) go straight to target
+      if (typeof key !== "string") return target[key];
+
+      const c0 = key.charCodeAt(0);
+
+      // Fast path: keys not starting with '$' (36) or '_' (95) are user properties.
+      // Skip all special-key checks entirely.
+      if (c0 !== 36 /* $ */ && c0 !== 95 /* _ */) {
+        if (key in target) return target[key];
+        if (parent && parent.__isProxy) return parent[key];
+        return undefined;
       }
+
+      // Dunder keys (__isProxy, __raw, __listeners)
+      if (c0 === 95) {
+        if (key === "__isProxy") return true;
+        if (key === "__raw") return target;
+        if (key === "__listeners") return listeners;
+        // Fall through to target/parent lookup for other _ keys
+        if (key in target) return target[key];
+        if (parent && parent.__isProxy) return parent[key];
+        return undefined;
+      }
+
+      // $ prefix: dispatch core context keys via switch for O(1) branching
+      switch (key) {
+        case "$watch":  return $watchFn;
+        case "$notify": return notify;
+        case "$set":    return $setFn;
+        case "$parent": return parent;
+        case "$refs":   return _refs;
+        case "$store":  return _stores;
+        case "$route":  return _routerInstance ? _routerInstance.current : {};
+        case "$router": return _routerInstance;
+        case "$i18n":   return _i18n;
+        case "$form":   return target.$form || null;
+      }
+
+      // Plugin globals fallback (after all core $ checks)
+      const globalKey = key.slice(1);
+      if (globalKey in _globals) return _globals[globalKey];
+
+      // Target / parent chain lookup
       if (key in target) return target[key];
       if (parent && parent.__isProxy) return parent[key];
       return undefined;

--- a/src/directives/loops.js
+++ b/src/directives/loops.js
@@ -106,14 +106,17 @@ const _loopHandler = {
       }
       prevList = list;
 
-      // Filter
+      // Filter — reuse a single proxy context, mutating its target per item
       if (filterExpr) {
+        const filterData = { [itemName]: undefined, [indexName]: 0 };
+        const filterCtx = createContext(filterData, ctx);
+        const filterRaw = filterCtx.__raw;
         list = list.filter((item, i) => {
-          const tempCtx = createContext(
-            { [itemName]: item, [indexName]: i },
-            ctx,
-          );
-          return !!evaluate(filterExpr, tempCtx);
+          filterRaw[itemName] = item;
+          filterRaw[indexName] = i;
+          // Invalidate _collectKeys cache since we bypassed the proxy setter
+          delete filterRaw.__collectKeysCache;
+          return !!evaluate(filterExpr, filterCtx);
         });
       }
 
@@ -204,9 +207,16 @@ const _loopHandler = {
       // On first render clear any residual content so only managed nodes appear.
       if (keyMap.size === 0) el.innerHTML = "";
 
+      // Reuse a single proxy context for key evaluation (same pattern as filter)
+      const keyData = { [itemName]: undefined, [indexName]: 0 };
+      const keyCtx = createContext(keyData, ctx);
+      const keyRaw = keyCtx.__raw;
       const newOrder = list.map((item, i) => {
-        const tempCtx = createContext({ [itemName]: item, [indexName]: i }, ctx);
-        return { key: evaluate(keyExpr, tempCtx), item, i };
+        keyRaw[itemName] = item;
+        keyRaw[indexName] = i;
+        // Invalidate _collectKeys cache since we bypassed the proxy setter
+        delete keyRaw.__collectKeysCache;
+        return { key: evaluate(keyExpr, keyCtx), item, i };
       });
 
       const nextKeySet = new Set(newOrder.map((e) => e.key));


### PR DESCRIPTION
## Summary

- **M2 — Proxy get trap reorder:** Add charCode-based fast path in `createContext()` get trap that skips all 14 special-key checks when the key doesn't start with `$` or `_`. For `$`-prefixed keys, replace sequential if-chain with a `switch` statement. Hoist `$watch` and `$set` closures outside the handler.
- **M4 — Reusable filter context:** Replace per-item `createContext()` calls in filter and key-based reconciliation loops with a single reusable proxy whose raw target is mutated per iteration. Eliminates N proxy allocations that are immediately GC'd (500 items = 500 proxies → 1 proxy). Invalidates `_collectKeys` cache after each raw mutation.

**Security invariant preserved:** Special keys (`$watch`, `$set`, `$parent`, etc.) are always checked before `target` lookup — users cannot shadow framework internals.

## Test plan

- [x] All 1470 unit tests pass (0 regressions)
- [x] Filter + sort + limit inline template test passes (validates reusable filter context correctness)
- [x] Key-based reconciliation tests pass (validates reusable key context correctness)
- [ ] Run `npm run bench` to measure perf improvement on loop-heavy scenarios