### PR TITLE
perf(loops): keyless loop delta optimization (NOJS-39)

### DIFF
--- a/src/directives/loops.js
+++ b/src/directives/loops.js
@@ -78,6 +78,10 @@ const _loopHandler = {
     const stagger = parseInt(el.getAttribute("animate-stagger")) || 0;
     const animDuration = parseInt(el.getAttribute("animate-duration")) || 0;
     let prevList = null;
+    // Tracks the last rendered (post-filter/sort/slice) list for delta optimization.
+    let prevRendered = null;
+    // Delta optimization is disabled when filter/sort/offset modify rendered order.
+    const hasPipeline = !!(filterExpr || sortProp || offset);
 
     // Capture inline children as template fragment (before any render).
     // When no external template is specified, the element's children become
@@ -145,12 +149,69 @@ const _loopHandler = {
           el.appendChild(clone);
           processTree(el);
         }
+        prevRendered = null;
         return;
       }
 
       if (keyExpr) {
         reconcileForeachItems(list, list.length);
+        prevRendered = null;
         return;
+      }
+
+      // ── Length-delta append optimization (keyless) ─────────────────────
+      // When the list grew and the existing prefix items are unchanged,
+      // append only the new items instead of tearing down and rebuilding
+      // everything. Falls back to full rebuild when filter/sort/offset are
+      // active (rendered order may differ from source order), when the list
+      // shrunk, or when any existing item reference changed.
+      function tryDeltaAppend() {
+        if (hasPipeline) return false;
+        if (!prevRendered) return false;
+        const oldLen = prevRendered.length;
+        const newLen = list.length;
+        if (newLen <= oldLen) return false;
+        if (el.children.length !== oldLen) return false;
+        // Shallow compare: every existing item reference must be identical.
+        for (let j = 0; j < oldLen; j++) {
+          if (list[j] !== prevRendered[j]) return false;
+        }
+        // Prefix matches — update $count and $last on existing children,
+        // then append only the delta items.
+        const count = newLen;
+        for (let j = 0; j < oldLen; j++) {
+          const childCtx = el.children[j].__ctx;
+          if (childCtx) {
+            const raw = childCtx.__raw;
+            raw.$count = count;
+            raw.$last = false;
+            // Invalidate _collectKeys cache since we bypassed the proxy setter
+            delete raw.__collectKeysCache;
+            childCtx.$notify();
+          }
+        }
+        for (let i = oldLen; i < newLen; i++) {
+          const childData = {
+            [itemName]: list[i],
+            [indexName]: i,
+            $index: i,
+            $count: count,
+            $first: false,
+            $last: i === count - 1,
+            $even: i % 2 === 0,
+            $odd: i % 2 !== 0,
+          };
+          const clone = tplId
+            ? document.getElementById(tplId)?.content.cloneNode(true)
+            : inlineTemplate?.cloneNode(true);
+          if (!clone) return false;
+          const { node, applyAnim } = _makeLoopItem(clone, createContext(childData, ctx), animEnter, stagger, i);
+          el.appendChild(node);
+          processTree(node);
+          applyAnim();
+        }
+        prevRendered = list.slice();
+        return true;
       }
 
       function renderForeachItems() {
@@ -177,6 +238,7 @@ const _loopHandler = {
           processTree(node);
           applyAnim();
         });
+        prevRendered = list.slice();
       }
 
       // Animate out old items if animate-leave is set
@@ -195,7 +257,7 @@ const _loopHandler = {
           // || 0: unblocks the next render on the next tick when no CSS animation fires.
           setTimeout(done, animDuration || 0);
         });
-      } else {
+      } else if (!tryDeltaAppend()) {
         renderForeachItems();
       }
     }


### PR DESCRIPTION
## Summary
- Adds a length-delta append optimization for keyless `foreach`/`each`/`for` loops in `src/directives/loops.js`
- When the list grows and the existing prefix items are unchanged (shallow reference equality), only the new delta items are cloned, contextualized, and processed — skipping a full dispose + rebuild cycle
- Falls back to full rebuild when `filter`/`sort`/`offset` attributes are active, the list shrunk, or any existing item reference changed
- Updates `$count` and `$last` on pre-existing children so iteration variables remain correct

## Technical details
- New `prevRendered` array tracks the last rendered (post-pipeline) list for comparison
- `hasPipeline` flag disables delta path when filter/sort/offset could alter rendered order
- `tryDeltaAppend()` performs O(n) shallow compare of existing prefix, then appends only the delta
- Existing `_disposeChildren` + `innerHTML = ""` fallback path is completely unchanged
- All 1621 existing tests pass with no modifications

## Test plan
- [x] All 1621 Jest unit tests pass
- [ ] Verify delta append with a growing list (e.g., chat messages, infinite scroll)
- [ ] Verify full rebuild fallback when items are mutated (replaced references)
- [ ] Verify full rebuild fallback when filter/sort/offset are active
- [ ] Verify `$count`, `$last`, `$first` are correct on all items after delta append
- [ ] Verify animate-leave still triggers full rebuild path