### PR TITLE
perf(globals): partitioned store watchers (NOJS-38)

### DIFF
--- a/__tests__/core.test.js
+++ b/__tests__/core.test.js
@@ -14,6 +14,8 @@ import {
   _warn,
   _notifyStoreWatchers,
   _watchExpr,
+  _addStoreWatcher,
+  _deleteStoreWatcher,
   _emitEvent,
   _setCurrentEl,
   _onDispose,
@@ -123,13 +125,29 @@ test('_cache is a Map', () => {
     test('calls all store watchers', () => {
       const fn1 = jest.fn();
       const fn2 = jest.fn();
-      _storeWatchers.add(fn1);
-      _storeWatchers.add(fn2);
+      _addStoreWatcher(fn1, 'cart');
+      _addStoreWatcher(fn2, 'user');
       _notifyStoreWatchers();
       expect(fn1).toHaveBeenCalled();
       expect(fn2).toHaveBeenCalled();
-      _storeWatchers.delete(fn1);
-      _storeWatchers.delete(fn2);
+      _deleteStoreWatcher(fn1);
+      _deleteStoreWatcher(fn2);
+    });
+
+    test('calls only targeted partition + wildcards', () => {
+      const fnCart = jest.fn();
+      const fnUser = jest.fn();
+      const fnWild = jest.fn();
+      _addStoreWatcher(fnCart, 'cart');
+      _addStoreWatcher(fnUser, 'user');
+      _addStoreWatcher(fnWild, '*');
+      _notifyStoreWatchers('cart');
+      expect(fnCart).toHaveBeenCalled();
+      expect(fnWild).toHaveBeenCalled();
+      expect(fnUser).not.toHaveBeenCalled();
+      _deleteStoreWatcher(fnCart);
+      _deleteStoreWatcher(fnUser);
+      _deleteStoreWatcher(fnWild);
     });
   });
 
@@ -159,10 +177,11 @@ test('_cache is a Map', () => {
     test('adds to _storeWatchers when expr includes $store', () => {
       const ctx = createContext({});
       const fn = jest.fn();
-      const sizeBefore = _storeWatchers.size;
+      const cartSetBefore = _storeWatchers.get('cart');
+      const sizeBefore = cartSetBefore ? cartSetBefore.size : 0;
       _watchExpr('$store.cart.items', ctx, fn);
-      expect(_storeWatchers.size).toBe(sizeBefore + 1);
-      _storeWatchers.delete(fn);
+      expect(_storeWatchers.get('cart').size).toBe(sizeBefore + 1);
+      _deleteStoreWatcher(fn);
     });
 
     test('registers _onDispose that calls unwatch on disposal', () => {
@@ -197,11 +216,11 @@ test('_cache is a Map', () => {
       _watchExpr('$store.cart.items', ctx, fn);
       _setCurrentEl(null);
 
-      expect(_storeWatchers.has(fn)).toBe(true);
+      expect(_storeWatchers.get('cart')?.has(fn)).toBe(true);
 
       _disposeTree(el);
 
-      expect(_storeWatchers.has(fn)).toBe(false);
+      expect(_storeWatchers.get('cart')?.has(fn) ?? false).toBe(false);
     });
 
     test('prunes $store watcher lazily via isConnected guard when element is removed without dispose', () => {
@@ -217,18 +236,18 @@ test('_cache is a Map', () => {
       _watchExpr('$store.cart', ctx, fn);
       _setCurrentEl(null);
 
-      expect(_storeWatchers.has(fn)).toBe(true);
+      expect(_storeWatchers.get('cart')?.has(fn)).toBe(true);
 
       // Remove element externally (bypassing framework dispose)
       parent.innerHTML = '';
 
-      // Watcher is still in the Set (no MutationObserver to eagerly remove it)
-      expect(_storeWatchers.has(fn)).toBe(true);
+      // Watcher is still in the partition (no MutationObserver to eagerly remove it)
+      expect(_storeWatchers.get('cart')?.has(fn)).toBe(true);
 
       // _notifyStoreWatchers prunes disconnected elements via isConnected guard
-      _notifyStoreWatchers();
+      _notifyStoreWatchers('cart');
 
-      expect(_storeWatchers.has(fn)).toBe(false);
+      expect(_storeWatchers.get('cart')?.has(fn) ?? false).toBe(false);
       // The watcher callback should NOT have been invoked for the disconnected element
       expect(fn).not.toHaveBeenCalled();
     });
@@ -247,14 +266,14 @@ test('_cache is a Map', () => {
       _watchExpr('$store.cart.items', ctx, fn);
       _setCurrentEl(null);
 
-      expect(_storeWatchers.has(fn)).toBe(true);
+      expect(_storeWatchers.get('cart')?.has(fn)).toBe(true);
 
       // Simulate each re-render: disposeTree then clear innerHTML
       _disposeTree(itemWrapper);
       container.innerHTML = '';
 
       // Watcher must be removed by the _onDispose path
-      expect(_storeWatchers.has(fn)).toBe(false);
+      expect(_storeWatchers.get('cart')?.has(fn) ?? false).toBe(false);
     });
 
     test('does not throw when element has no parentElement', () => {
@@ -268,7 +287,7 @@ test('_cache is a Map', () => {
       expect(() => _watchExpr('$store.x', ctx, fn)).not.toThrow();
       _setCurrentEl(null);
 
-      _storeWatchers.delete(fn);
+      _deleteStoreWatcher(fn);
     });
   });
 });

--- a/__tests__/integration.test.js
+++ b/__tests__/integration.test.js
@@ -391,44 +391,44 @@ describe('NoJS.notify()', () => {
   });
 
   test('triggers store watchers', () => {
-    const { _storeWatchers } = require('../src/globals.js');
+    const { _addStoreWatcher, _deleteStoreWatcher } = require('../src/globals.js');
     const fn1 = jest.fn();
     const fn2 = jest.fn();
-    _storeWatchers.add(fn1);
-    _storeWatchers.add(fn2);
+    _addStoreWatcher(fn1, 'test');
+    _addStoreWatcher(fn2, 'test');
 
     NoJS.notify();
 
     expect(fn1).toHaveBeenCalledTimes(1);
     expect(fn2).toHaveBeenCalledTimes(1);
 
-    _storeWatchers.delete(fn1);
-    _storeWatchers.delete(fn2);
+    _deleteStoreWatcher(fn1);
+    _deleteStoreWatcher(fn2);
   });
 
   test('prunes disconnected element watchers', () => {
-    const { _storeWatchers } = require('../src/globals.js');
+    const { _addStoreWatcher, _storeWatchers } = require('../src/globals.js');
     const fn = jest.fn();
     fn._el = { isConnected: false };
-    _storeWatchers.add(fn);
+    _addStoreWatcher(fn, 'test');
 
     NoJS.notify();
 
     expect(fn).not.toHaveBeenCalled();
-    expect(_storeWatchers.has(fn)).toBe(false);
+    expect(_storeWatchers.get('test')?.has(fn) ?? false).toBe(false);
   });
 
   test('multiple rapid calls do not break anything', () => {
-    const { _storeWatchers } = require('../src/globals.js');
+    const { _addStoreWatcher, _deleteStoreWatcher } = require('../src/globals.js');
     const fn = jest.fn();
-    _storeWatchers.add(fn);
+    _addStoreWatcher(fn, 'test');
 
     NoJS.notify();
     NoJS.notify();
     NoJS.notify();
 
     expect(fn).toHaveBeenCalledTimes(3);
-    _storeWatchers.delete(fn);
+    _deleteStoreWatcher(fn);
   });
 
   test('DOM updates after external store mutation + notify()', async () => {

--- a/__tests__/phase2-perf.test.js
+++ b/__tests__/phase2-perf.test.js
@@ -10,7 +10,7 @@
  * PR #64 — NOJS-35: Proxy get trap + reusable filter context (M2, M4)
  */
 
-import { _config, _stores, _storeWatchers, _setCurrentEl, _onDispose, _watchExpr, _notifyStoreWatchers, _refs, _globals } from '../src/globals.js';
+import { _config, _stores, _storeWatchers, _setCurrentEl, _onDispose, _watchExpr, _notifyStoreWatchers, _addStoreWatcher, _deleteStoreWatcher, _refs, _globals } from '../src/globals.js';
 import { createContext, _startBatch, _endBatch, _collectKeys, _resetCtxId } from '../src/context.js';
 import { evaluate, resolve, _execStatement, _exprCache, _stmtCache } from '../src/evaluate.js';
 import { registerDirective, processElement, processTree, _disposeTree, _disposeChildren } from '../src/registry.js';
@@ -404,12 +404,12 @@ describe('PR #61 — Prototype-based scope in evaluate()', () => {
       _stores.counter = { value: 0 };
       const ctx = createContext({});
       const watcher = jest.fn();
-      _storeWatchers.add(watcher);
+      _addStoreWatcher(watcher, 'counter');
 
       _execStatement('$store.counter.value = 42', ctx, {});
 
       expect(watcher).toHaveBeenCalled();
-      _storeWatchers.delete(watcher);
+      _deleteStoreWatcher(watcher);
       delete _stores.counter;
     });
   });
@@ -637,18 +637,18 @@ describe('PR #63 — MutationObserver removal: store reactivity', () => {
       _watchExpr('$store.app.value', ctx, fn);
       _setCurrentEl(null);
 
-      expect(_storeWatchers.has(fn)).toBe(true);
+      expect(_storeWatchers.get('app')?.has(fn)).toBe(true);
 
       // Remove element from DOM (without dispose)
       parent.removeChild(el);
 
-      // Watcher still in Set (no MutationObserver to eagerly remove)
-      expect(_storeWatchers.has(fn)).toBe(true);
+      // Watcher still in partition (no MutationObserver to eagerly remove)
+      expect(_storeWatchers.get('app')?.has(fn)).toBe(true);
 
       // Trigger notification — lazy pruning should remove it
-      _notifyStoreWatchers();
+      _notifyStoreWatchers('app');
 
-      expect(_storeWatchers.has(fn)).toBe(false);
+      expect(_storeWatchers.get('app')?.has(fn) ?? false).toBe(false);
       expect(fn).not.toHaveBeenCalled();
 
       document.body.removeChild(parent);
@@ -691,12 +691,12 @@ describe('PR #63 — MutationObserver removal: store reactivity', () => {
       _watchExpr('$store.app.value', ctx, fn);
       _setCurrentEl(null);
 
-      expect(_storeWatchers.has(fn)).toBe(true);
+      expect(_storeWatchers.get('app')?.has(fn)).toBe(true);
 
       // Proper disposal path
       _disposeTree(el);
 
-      expect(_storeWatchers.has(fn)).toBe(false);
+      expect(_storeWatchers.get('app')?.has(fn) ?? false).toBe(false);
 
       document.body.removeChild(container);
     });
@@ -769,13 +769,13 @@ describe('PR #63 — MutationObserver removal: store reactivity', () => {
       _watchExpr('$store.nav.page', ctx, fn1);
       _setCurrentEl(null);
 
-      expect(_storeWatchers.has(fn1)).toBe(true);
+      expect(_storeWatchers.get('nav')?.has(fn1)).toBe(true);
 
       // Simulate route transition: dispose old, insert new
       _disposeTree(page1);
       outlet.innerHTML = '';
 
-      expect(_storeWatchers.has(fn1)).toBe(false);
+      expect(_storeWatchers.get('nav')?.has(fn1) ?? false).toBe(false);
 
       const page2 = document.createElement('div');
       outlet.appendChild(page2);

--- a/__tests__/registry.test.js
+++ b/__tests__/registry.test.js
@@ -1,6 +1,6 @@
 import { registerDirective, processElement, processTree, _disposeTree, _disposeChildren } from '../src/registry.js';
 import { createContext } from '../src/context.js';
-import { _setCurrentEl, _onDispose, _storeWatchers } from '../src/globals.js';
+import { _setCurrentEl, _onDispose, _storeWatchers, _addStoreWatcher } from '../src/globals.js';
 import { _i18nListeners } from '../src/i18n.js';
 
 describe('Directive Registry', () => {
@@ -182,14 +182,14 @@ describe('Disposal', () => {
 
     test('clears context __listeners and removes from _storeWatchers', () => {
       const fn = jest.fn();
-      _storeWatchers.add(fn);
+      _addStoreWatcher(fn, 'test');
 
       const el = document.createElement('div');
       el.__ctx = { __listeners: new Set([fn]) };
 
       _disposeTree(el);
 
-      expect(_storeWatchers.has(fn)).toBe(false);
+      expect(_storeWatchers.get('test')?.has(fn) ?? false).toBe(false);
       expect(el.__ctx.__listeners.size).toBe(0);
     });
 

--- a/src/directives/http.js
+++ b/src/directives/http.js
@@ -184,7 +184,7 @@ for (const method of HTTP_METHODS) {
           if (intoStore) {
             if (!_stores[intoStore]) _stores[intoStore] = createContext({});
             _stores[intoStore].$set(asKey, data);
-            _notifyStoreWatchers();
+            _notifyStoreWatchers(intoStore);
           }
 
           // Success template

--- a/src/directives/refs.js
+++ b/src/directives/refs.js
@@ -159,7 +159,7 @@ registerDirective("call", {
         if (intoStore) {
           if (!_stores[intoStore]) _stores[intoStore] = createContext({});
           _stores[intoStore].$set(asKey, data);
-          _notifyStoreWatchers();
+          _notifyStoreWatchers(intoStore);
         }
         if (thenExpr) _execStatement(thenExpr, ctx, { result: data });
         if (successTpl) {

--- a/src/evaluate.js
+++ b/src/evaluate.js
@@ -2,7 +2,7 @@
 //  EXPRESSION EVALUATOR
 // ═══════════════════════════════════════════════════════════════════════
 
-import { _config, _stores, _routerInstance, _filters, _warn, _notifyStoreWatchers, _globals } from "./globals.js";
+import { _config, _stores, _routerInstance, _filters, _warn, _notifyStoreWatchers, _extractStoreName, _globals } from "./globals.js";
 import { _i18n } from "./i18n.js";
 import { _collectKeys } from "./context.js";
 
@@ -1438,7 +1438,7 @@ export function _execStatement(expr, ctx, extraVars = {}) {
 
     // Notify global store watchers when expression touches $store
     if (typeof expr === "string" && expr.includes("$store")) {
-      _notifyStoreWatchers();
+      _notifyStoreWatchers(_extractStoreName(expr));
     }
   } catch (e) {
     _warn("Expression error:", expr, e.message);

--- a/src/globals.js
+++ b/src/globals.js
@@ -27,7 +27,7 @@ export const _config = {
 export const _interceptors = { request: [], response: [] };
 export const _eventBus = {};
 export const _stores = {};
-export const _storeWatchers = new Set();
+export const _storeWatchers = new Map(); // storeName → Set<fn>, '*' = wildcard
 export const _filters = {};
 export const _validators = {};
 export const _cache = new Map();
@@ -79,13 +79,64 @@ export function _warn(...args) {
   console.warn("[No.JS]", ...args);
 }
 
-export function _notifyStoreWatchers() {
-  for (const fn of _storeWatchers) {
+// Regex to extract the first store name from expressions like $store.cart.items
+const _STORE_NAME_RE = /\$store\.(\w+)/;
+
+export function _extractStoreName(expr) {
+  if (typeof expr !== "string") return null;
+  const m = _STORE_NAME_RE.exec(expr);
+  return m ? m[1] : null;
+}
+
+function _notifyPartition(set) {
+  for (const fn of set) {
     if (fn._el && !fn._el.isConnected) {
-      _storeWatchers.delete(fn);
+      set.delete(fn);
       continue;
     }
     fn();
+  }
+}
+
+export function _notifyStoreWatchers(storeName) {
+  if (storeName) {
+    // Notify only the targeted partition + wildcards
+    const partition = _storeWatchers.get(storeName);
+    if (partition) _notifyPartition(partition);
+    const wildcard = _storeWatchers.get("*");
+    if (wildcard) _notifyPartition(wildcard);
+  } else {
+    // No store name — notify ALL partitions (backward compat)
+    for (const set of _storeWatchers.values()) {
+      _notifyPartition(set);
+    }
+  }
+}
+
+export function _addStoreWatcher(fn, partition) {
+  let set = _storeWatchers.get(partition);
+  if (!set) {
+    set = new Set();
+    _storeWatchers.set(partition, set);
+  }
+  set.add(fn);
+  fn._storePartition = partition;
+}
+
+export function _deleteStoreWatcher(fn) {
+  const partition = fn._storePartition;
+  if (partition) {
+    const set = _storeWatchers.get(partition);
+    if (set) {
+      set.delete(fn);
+      if (set.size === 0) _storeWatchers.delete(partition);
+    }
+  } else {
+    // Fallback: scan all partitions (legacy safety net)
+    for (const [key, set] of _storeWatchers) {
+      set.delete(fn);
+      if (set.size === 0) _storeWatchers.delete(key);
+    }
   }
 }
 
@@ -93,10 +144,11 @@ export function _watchExpr(expr, ctx, fn) {
   const unwatch = ctx.$watch(fn);
   _onDispose(() => {
     unwatch();
-    _storeWatchers.delete(fn);
+    _deleteStoreWatcher(fn);
   });
   if (typeof expr === "string" && expr.includes("$store")) {
-    _storeWatchers.add(fn);
+    const partition = _extractStoreName(expr) || "*";
+    _addStoreWatcher(fn, partition);
     fn._el = _currentEl;
   }
 }

--- a/src/registry.js
+++ b/src/registry.js
@@ -2,7 +2,7 @@
 //  DIRECTIVE REGISTRY & DOM PROCESSING
 // ═══════════════════════════════════════════════════════════════════════
 
-import { _currentEl, _setCurrentEl, _storeWatchers, _warn } from "./globals.js";
+import { _currentEl, _setCurrentEl, _deleteStoreWatcher, _warn } from "./globals.js";
 import { _i18nListeners } from "./i18n.js";
 import { _devtoolsEmit, _ctxRegistry } from "./devtools.js";
 
@@ -100,7 +100,7 @@ function _disposeElement(node) {
 
   if (node.__ctx && node.__ctx.__listeners) {
     for (const fn of node.__ctx.__listeners) {
-      _storeWatchers.delete(fn);
+      _deleteStoreWatcher(fn);
       _i18nListeners.delete(fn);
     }
     node.__ctx.__listeners.clear();


### PR DESCRIPTION
## Summary

- Replace flat `Set<fn>` store watcher structure with `Map<storeName, Set<fn>>` so `_notifyStoreWatchers()` only fires watchers for the affected store partition plus wildcard (`*`) watchers, reducing notification cost from O(N) to O(K) where K is the number of watchers for that specific store
- Callers with known store names (`refs.js`, `http.js`, `evaluate.js`) now pass the store name; `NoJS.notify()` and global set broadcast to all partitions for backward compatibility
- Added `_addStoreWatcher()`, `_deleteStoreWatcher()`, and `_extractStoreName()` helpers for partition management and cleanup

## Test plan

- [x] All 1622 existing unit tests pass (20 suites, 0 failures)
- [x] New test added: `calls only targeted partition + wildcards` verifies selective notification
- [x] Disposal cleanup verified: `_disposeTree`, `_onDispose`, and `registry.js` `_disposeElement` all remove from correct partition
- [x] Lazy pruning (isConnected guard) works per-partition
- [x] `NoJS.notify()` still broadcasts to all partitions (backward compat)
- [x] Expressions without extractable store name go to wildcard `*` partition