### PR TITLE
NOJS-53: Fix error-boundary window listener (capture + window target)

### DIFF
--- a/src/directives/error-boundary.js
+++ b/src/directives/error-boundary.js
@@ -37,13 +37,20 @@ registerDirective("error-boundary", {
     el.addEventListener("nojs:error", nojsErrorHandler);
     _onDispose(() => el.removeEventListener("nojs:error", nojsErrorHandler));
 
-    // Listen for window-level errors (resource load failures, etc.)
+    // Listen for window-level errors (resource load failures, uncaught JS errors)
+    // Use capture phase because resource load errors (e.g. <img> 404) don't bubble
     const errorHandler = (e) => {
-      if (el.contains(e.target) || el === e.target) {
+      if (e.target === window) {
+        // Uncaught JS error: target is window, show fallback if boundary is connected
+        if (el.isConnected) {
+          showFallback(e.message || "An error occurred");
+        }
+      } else if (el.contains(e.target) || el === e.target) {
+        // Resource load error on a child element
         showFallback(e.message || "An error occurred");
       }
     };
-    window.addEventListener("error", errorHandler);
-    _onDispose(() => window.removeEventListener("error", errorHandler));
+    window.addEventListener("error", errorHandler, { capture: true });
+    _onDispose(() => window.removeEventListener("error", errorHandler, { capture: true }));
   },
 });


### PR DESCRIPTION
## Summary

- Add `{ capture: true }` to `window.addEventListener("error", ...)` and the matching `removeEventListener` so that resource load failures on child elements (e.g. `<img>` 404) are caught — these error events do not bubble, they only propagate in the capture phase.
- Handle `e.target === window` for uncaught JS errors: when the error target is `window`, the boundary shows fallback if `el.isConnected` is true, since `el.contains(window)` always returns false.
- Errors on elements outside the boundary still do not trigger fallback (the `el.contains(e.target)` guard remains intact for resource errors).

## Test plan

- [ ] Verify `<img src="nonexistent.jpg">` inside an error-boundary triggers the fallback
- [ ] Verify uncaught JS errors show fallback when boundary is connected
- [ ] Verify errors on elements outside the boundary do not trigger fallback
- [ ] Verify cleanup in `_onDispose` correctly removes the capture-phase listener
- [ ] All existing Jest tests pass (1581/1581)