### PR TITLE
NOJS-57: Re-protect replaced directives in registry

### DIFF
--- a/src/registry.js
+++ b/src/registry.js
@@ -19,7 +19,7 @@ export function registerDirective(name, handler) {
     priority: handler.priority ?? 50,
     init: handler.init,
   });
-  if (!_frozen) _coreDirectives.add(name);
+  _coreDirectives.add(name);
 }
 
 export function _freezeDirectives() {


### PR DESCRIPTION
## Summary

- Removes the `!_frozen` guard from `_coreDirectives.add(name)` in `registerDirective()`, so that directives registered after freeze (e.g., Elements replacements via `_removeCoreDirective` + `registerDirective`) are re-added to `_coreDirectives` and protected from subsequent overwrites by third-party plugins.

## Rationale

Before this fix, `_removeCoreDirective(name)` deleted the name from `_coreDirectives`, and the replacement directive registered by Elements was never re-added because the `!_frozen` guard blocked `_coreDirectives.add(name)` post-freeze. This left the replacement unprotected -- any subsequent plugin could silently overwrite it.

The fix is safe because:
- **Before freeze**: directives are added to `_coreDirectives` (same behavior as before)
- **After freeze**: a directive that passes the guard (not in `_coreDirectives`) gets registered AND re-added to `_coreDirectives`, making it protected again
- **Frozen core directives**: still blocked by the existing guard on line 14

## Test plan

- [x] All 22 registry tests pass
- [x] All 59 plugin-system tests pass (including T7.29 core directive override rejection and T7.30 pattern directive override rejection)