### PR TITLE
NOJS-55: Add $form shim to validate-stub

### DIFF
--- a/src/directives/validate-stub.js
+++ b/src/directives/validate-stub.js
@@ -1,5 +1,15 @@
-import { _warn } from "../globals.js";
+import { _warn, _onDispose } from "../globals.js";
+import { findContext } from "../dom.js";
 import { registerDirective } from "../registry.js";
+
+// ─── Proxy for $form.fields — returns safe defaults for any field access ────
+const _FIELD_DEFAULT = Object.freeze({
+  valid: true, dirty: false, touched: false, error: null, value: "",
+});
+
+const _fieldsProxy = new Proxy({}, {
+  get: () => _FIELD_DEFAULT,
+});
 
 registerDirective("validate", {
   priority: 30,
@@ -8,5 +18,34 @@ registerDirective("validate", {
       `[NoJS] "validate" has moved to @erickxavier/nojs-elements. ` +
       `Install the plugin and call NoJS.use(NoJSElements) to enable it.`
     );
+
+    // Set a minimal $form shim so templates referencing $form.* don't throw
+    const ctx = findContext(el);
+    ctx.$form = {
+      valid: false,
+      dirty: false,
+      touched: false,
+      submitting: false,
+      pending: false,
+      errors: {},
+      values: {},
+      firstError: null,
+      errorCount: 0,
+      fields: _fieldsProxy,
+      reset() {},
+    };
+
+    // Intercept form submit to prevent silent failures
+    const form = el.tagName === "FORM" ? el : el.closest("form");
+    if (form) {
+      const handler = (e) => {
+        e.preventDefault();
+        _warn(
+          `[NoJS] Form submission blocked — "validate" requires @erickxavier/nojs-elements.`
+        );
+      };
+      form.addEventListener("submit", handler);
+      _onDispose(() => form.removeEventListener("submit", handler));
+    }
   },
 });


### PR DESCRIPTION
## Summary

- Add a minimal `$form` shim to the validate-stub directive so templates referencing `$form.valid`, `$form.fields`, `$form.errors`, etc. don't throw at runtime when NoJS-Elements is not installed
- Use a `Proxy`-backed `fields` object that returns safe defaults (`{ valid: true, dirty: false, touched: false, error: null, value: "" }`) for any field access
- Intercept form `submit` events with `preventDefault()` and a warning message, with proper cleanup via `_onDispose()`
- Preserve the existing `_warn()` migration message

## Test plan

- [x] Build succeeds (`node build.js`)
- [x] All 1581 unit tests pass (`npx jest --no-coverage`)
- [ ] Verify `$form.valid` access in a template without Elements installed does not throw
- [ ] Verify `$form.fields.email.valid` returns `true` (Proxy default)
- [ ] Verify form submission is blocked with a console warning
- [ ] Verify event listener is cleaned up on disposal