### PR TITLE
fix(docs): no-js.dev loads from CDN, not stale local ./no.js

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -191,7 +191,7 @@
   </button>
 
   <!-- ═══ Scripts ═══ -->
-  <script src="./no.js"></script>
+  <script src="https://cdn.no-js.dev/"></script>
   <script>
     // ── Global NoJS configuration ──
     NoJS.config({


### PR DESCRIPTION
The live site (`docs/index.html`, GitHub Pages) loaded `src="./no.js"` — a local bundle frozen at v1.12.0 that was never refreshed on the 1.13.0/1.13.1 builds. Switched to `https://cdn.no-js.dev/` (serves the current 1.13.1 iife build, matches the form documented in our own getting-started/landing samples). No version bump — docs-only.

Note: `docs/no.js` (stale 1.12.0) is now unreferenced; can be removed in a follow-up.