### PR TITLE
fix/NOJS-59-reintegrate/NOJS-73: Core regression gate

### DIFF
--- a/__tests__/core.test.js
+++ b/__tests__/core.test.js
@@ -1873,10 +1873,12 @@ describe('evaluate — browser globals allow-list', () => {
     expect(window.fetch).toBe(original);
   });
 
-  test('window user-defined property writes are allowed', () => {
+  test('window user-defined property writes are NOT persisted to the real window (NOJS-60 #28)', () => {
+    // Writing arbitrary props through the safe-window proxy must not pollute the
+    // real window (no global creation/override from a template expression).
+    expect(window.__testProp).toBeUndefined();
     _execStatement("window.__testProp = 42", createContext({}));
-    expect(window.__testProp).toBe(42);
-    delete window.__testProp;
+    expect(window.__testProp).toBeUndefined();
   });
 });
 

--- a/__tests__/directives-data.test.js
+++ b/__tests__/directives-data.test.js
@@ -546,15 +546,19 @@ describe('HTTP GET with then expression', () => {
     const el = document.createElement('div');
     el.setAttribute('get', '/api/check');
     el.setAttribute('as', 'resp');
-    el.setAttribute('then', 'window.__thenRan = true');
+    // NOJS-60 #28: writing to the real window from an expression is now a no-op,
+    // so the `then` probe writes to a context state variable instead.
+    el.setAttribute('then', 'fetched = true');
+    const probe = document.createElement('span');
+    probe.setAttribute('bind', 'fetched');
     parent.appendChild(el);
+    parent.appendChild(probe);
     document.body.appendChild(parent);
 
     processTree(parent);
     await flush();
 
-    expect(window.__thenRan).toBe(true);
-    delete window.__thenRan;
+    expect(probe.textContent).toBe('true');
   });
 });
 


### PR DESCRIPTION
## NOJS-73 — Core regression gate on \`fix/NOJS-59-reintegrate\`

QA regression gate for the Core hardening reintegration. Branch ports window-write test expectations to the hardened contract (commit \`7790094\`, +8/-3 \`__tests__/core.test.js\`, +10/-3 \`__tests__/directives-data.test.js\`) and runs the full gate.

### 1. Jest (unit) — GREEN
\`npm test\`
- **1583 passed, 3 skipped, 0 failed** (1586 total)
- 22 suites passed, 22 total

### 2. Playwright (E2E) — 12 pre-existing docs-site failures (NOT a Core regression)
\`npm run test:e2e\` (Chromium + Firefox + WebKit, single clean run)
- **326 passed, 31 skipped, 12 failed**
- Per-engine: each engine ran the full matrix; the 12 failures are **4 tests × 3 engines** (chromium 4, firefox 4, webkit 4) — consistent across all engines, not flaky.
- Failing tests, all in \`e2e/tests/tools-dropdown.spec.ts\` (docs-site ecosystem dropdown):
  - \`:50\` — 3 — All tool links are present with correct hrefs
  - \`:64\` — 4 — All links open in a new tab
  - \`:76\` — 5 — Each link shows a name and description
  - \`:198\` — 11 — Tools dropdown descriptions are localized in Spanish
- **Root cause:** docs-site i18n/content drift. The ecosystem tools dropdown now lists a different set/order of tools than the fixture expects (assertion expected \`Extensión VS Code\` / count 2; locale now serves \`Drag, drop y validación\`). This is **docs-site fixture drift inherited from the integration base \`6605ecc\`** — it touches no Core runtime (no directive/evaluate/fetch/router/Safety Rule). This branch's only commit modifies two Jest files and cannot affect E2E.
- 31 skipped = View-Transition / non-Chromium-fallback tests skipped on Firefox/WebKit by design.

### 3. Production build — GREEN
\`node build.js\` succeeds (iife/esm/cjs).
- \`grep -c 1.13.1 dist/iife/no.js\` = **2** (> 0). Version stays 1.13.1 (release task bumps later).
- No \`dist/\` changes vs source — build artifacts already current; nothing to commit.

### 4. Spot-audit
**Crit/High Core findings (vs 2026-05-29 deep review) — 17/18 fixed:**
- #2/#3 evaluate.js — own-property check (\`_hasOwn.call\`) replaces \`in\`; prototype members no longer resolve. FIXED
- #4 fetch.js — \`try/finally { clearTimeout }\`. FIXED
- #5 fetch.js — external-signal abort listener removed in \`finally\`. FIXED
- #6 filters.js — date-only ISO parsed as local (\`T00:00:00\`, \`_DATE_ONLY_RE\`). FIXED
- #7 registry.js — \`_coreDirectives\` guard only blocks frozen core names. FIXED
- #8 index.js — \`NoJS.global()\` deep-checks proxies via \`__raw\`. FIXED
- #9 state.js — \`__\`-prefixed keys filtered before persist. FIXED
- #10 binding.js — model skips \`el.value\` write when \`document.activeElement === el\`. FIXED
- #11 binding.js — bind-value \`isNaN\` guard. FIXED
- #12 conditionals.js — switch re-runs \`processTree\` on re-matched inline case. FIXED
- #13 refs.js — \`call\` disposes prior result wrapper. FIXED
- #14 devtools.js — \`_safeSnapshot\` cycle guard via WeakSet. FIXED
- #28/#29 context.js — per-listener try/catch in notify + \`_endBatch\`. FIXED
- #30 router.js — \`_clearOutlets\` disposes children, not the outlet. FIXED
- #31 router.js — per-navigation \`routeSnapshot\` passed into VT update callback. FIXED
- **#15 error-boundary.js — re-entrancy guard NOT present.** \`showFallback\` has no re-entrancy flag; a fallback containing a broken resource (e.g. \`<img>\` 404) re-fires the capture-phase \`error\` handler → \`showFallback\` again → infinite render loop. This HIGH finding is genuinely unaddressed on this branch and untested. Pre-existing (predates NOJS-73); flagged for a follow-up task.

**NoJS Safety Rules:** none regressed. Rule 1 (dispose-before-clear) verified in router/refs/conditionals/error-boundary; Rule 2 (listener cleanup) in fetch/error-boundary; Rule 7 (allow-list) hardened via own-property checks; Rule 8 (error isolation) hardened via per-listener try/catch.

**Extraction INTACT:** \`src/directives/\` contains only \`dnd-stub.js\` (15 lines) and \`validate-stub.js\` (52 lines) — genuine deprecation stubs that warn and delegate to \`@erickxavier/nojs-elements\`. No \`dnd*.js\` / \`validation.js\` full implementations resurrected.

### Verdict
Jest GREEN, build GREEN, extraction intact. E2E has 12 consistent failures isolated to a docs-site i18n fixture (\`tools-dropdown.spec.ts\`), unrelated to Core runtime and inherited from the base. One HIGH review finding (#15 error-boundary re-entrancy) remains unfixed on this branch. **DONE_WITH_CONCERNS** — recommend a follow-up for #15 and a docs-site fixture sync for the tools-dropdown specs.