### PR TITLE
docs: add jsDelivr CDN badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 </h1>
 
 ![version](https://img.shields.io/badge/version-1.13.1-blue)
+[![jsDelivr hits](https://data.jsdelivr.com/v1/package/gh/erickxavier/no-js/badge)](https://www.jsdelivr.com/package/gh/erickxavier/no-js)
 
 **The HTML-First Reactive Framework**
 


### PR DESCRIPTION
Adds a jsDelivr CDN hits badge to the README, pointing to this repo's own GitHub package on jsDelivr. Docs-only change; no version bump and no code touched.