### PR TITLE
NOJS-76: fix error-boundary re-entrancy guard

### DIFF
--- a/__tests__/directives-core.test.js
+++ b/__tests__/directives-core.test.js
@@ -3581,3 +3581,78 @@ describe('_makeLoopItem: single-root vs multi-root template promotion', () => {
     expect(children[0].querySelector('b').textContent).toBe('0');
   });
 });
+
+// ═══════════════════════════════════════════════════════════════════════
+//  NOJS-76: error-boundary re-entrancy guard
+// ═══════════════════════════════════════════════════════════════════════
+
+describe('Error-boundary re-entrancy guard (NOJS-76)', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+    Object.keys(_stores).forEach((k) => delete _stores[k]);
+  });
+
+  test('does not recurse when fallback template triggers a secondary error', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    // Create a fallback template
+    const fallbackTpl = document.createElement('template');
+    fallbackTpl.id = 'reentrant-fallback';
+    fallbackTpl.innerHTML = '<div class="fallback-content">Fallback rendered</div>';
+    document.body.appendChild(fallbackTpl);
+
+    const parent = document.createElement('div');
+    parent.setAttribute('state', '{}');
+    const boundary = document.createElement('div');
+    boundary.setAttribute('error-boundary', '#reentrant-fallback');
+    boundary.innerHTML = '<p>Normal content</p>';
+    parent.appendChild(boundary);
+    document.body.appendChild(parent);
+
+    processTree(parent);
+
+    // Simulate re-entrancy: intercept appendChild on the boundary so that
+    // when showFallback appends the fallback wrapper, we synchronously
+    // fire a window-level error event targeting the boundary. The
+    // directive's capture-phase window error handler calls showFallback
+    // again — the _handling guard must suppress the recursive call.
+    let secondaryFired = false;
+    const origAppendChild = Element.prototype.appendChild;
+    const patchedAppendChild = function (node) {
+      const result = origAppendChild.call(this, node);
+      if (this === boundary && !secondaryFired) {
+        secondaryFired = true;
+        // Dispatch a nojs:error while showFallback is mid-execution
+        boundary.dispatchEvent(new CustomEvent('nojs:error', {
+          detail: { message: 'Secondary error inside fallback' },
+        }));
+      }
+      return result;
+    };
+    Element.prototype.appendChild = patchedAppendChild;
+
+    // Dispatch the primary error — triggers showFallback
+    boundary.dispatchEvent(new CustomEvent('nojs:error', {
+      detail: { message: 'Primary error' },
+    }));
+
+    // Restore appendChild
+    Element.prototype.appendChild = origAppendChild;
+
+    // The fallback content should be present (primary error was handled)
+    expect(boundary.querySelector('.fallback-content')).not.toBeNull();
+
+    // The secondary error must have been dispatched
+    expect(secondaryFired).toBe(true);
+
+    // _warn should have been called for the suppressed secondary error
+    // _warn() prepends "[No.JS]" as the first arg, so the message is at index 1
+    const warnCalls = warnSpy.mock.calls.filter(
+      (call) => call[1] && call[1].includes('secondary error inside fallback')
+    );
+    expect(warnCalls.length).toBe(1);
+    expect(warnCalls[0][2]).toBe('Secondary error inside fallback');
+
+    warnSpy.mockRestore();
+  });
+});

--- a/src/directives/error-boundary.js
+++ b/src/directives/error-boundary.js
@@ -2,7 +2,7 @@
 //  DIRECTIVE: error-boundary
 // ═══════════════════════════════════════════════════════════════════════
 
-import { _onDispose } from "../globals.js";
+import { _onDispose, _warn } from "../globals.js";
 import { createContext } from "../context.js";
 import { findContext, _cloneTemplate } from "../dom.js";
 import { registerDirective, processTree, _disposeChildren } from "../registry.js";
@@ -11,22 +11,32 @@ registerDirective("error-boundary", {
   priority: 1,
   init(el, name, fallbackTpl) {
     const ctx = findContext(el);
+    let _handling = false;
 
     function showFallback(message) {
-      const clone = _cloneTemplate(fallbackTpl);
-      if (clone) {
-        const childCtx = createContext(
-          { err: { message } },
-          ctx,
-        );
-        _disposeChildren(el);
-        el.innerHTML = "";
-        const wrapper = document.createElement("div");
-        wrapper.style.display = "contents";
-        wrapper.__ctx = childCtx;
-        wrapper.appendChild(clone);
-        el.appendChild(wrapper);
-        processTree(wrapper);
+      if (_handling) {
+        _warn("error-boundary: secondary error inside fallback (suppressed to prevent infinite recursion):", message);
+        return;
+      }
+      _handling = true;
+      try {
+        const clone = _cloneTemplate(fallbackTpl);
+        if (clone) {
+          const childCtx = createContext(
+            { err: { message } },
+            ctx,
+          );
+          _disposeChildren(el);
+          el.innerHTML = "";
+          const wrapper = document.createElement("div");
+          wrapper.style.display = "contents";
+          wrapper.__ctx = childCtx;
+          wrapper.appendChild(clone);
+          el.appendChild(wrapper);
+          processTree(wrapper);
+        }
+      } finally {
+        _handling = false;
       }
     }
 


### PR DESCRIPTION
## Summary

- Add a boolean `_handling` guard to `showFallback` in `src/directives/error-boundary.js` that prevents recursive entry when the fallback template itself triggers an error
- Secondary errors during fallback rendering are surfaced via `_warn()` instead of causing infinite recursion
- Import `_warn` from `globals.js` for the suppression warning

## Test plan

- [x] Unit test added to `__tests__/directives-core.test.js` verifying that a secondary `nojs:error` dispatched during `showFallback` execution is suppressed and warned
- [x] All 176 tests in `directives-core.test.js` pass
- [x] All 81 tests in `directives-data.test.js` pass (existing error-boundary tests)