### PR TITLE
fix(core): error-boundary re-entrancy guard + tools-dropdown e2e fixtures

### DIFF
--- a/__tests__/directives-core.test.js
+++ b/__tests__/directives-core.test.js
@@ -3581,3 +3581,78 @@ describe('_makeLoopItem: single-root vs multi-root template promotion', () => {
     expect(children[0].querySelector('b').textContent).toBe('0');
   });
 });
+
+// ═══════════════════════════════════════════════════════════════════════
+//  NOJS-76: error-boundary re-entrancy guard
+// ═══════════════════════════════════════════════════════════════════════
+
+describe('Error-boundary re-entrancy guard (NOJS-76)', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+    Object.keys(_stores).forEach((k) => delete _stores[k]);
+  });
+
+  test('does not recurse when fallback template triggers a secondary error', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    // Create a fallback template
+    const fallbackTpl = document.createElement('template');
+    fallbackTpl.id = 'reentrant-fallback';
+    fallbackTpl.innerHTML = '<div class="fallback-content">Fallback rendered</div>';
+    document.body.appendChild(fallbackTpl);
+
+    const parent = document.createElement('div');
+    parent.setAttribute('state', '{}');
+    const boundary = document.createElement('div');
+    boundary.setAttribute('error-boundary', '#reentrant-fallback');
+    boundary.innerHTML = '<p>Normal content</p>';
+    parent.appendChild(boundary);
+    document.body.appendChild(parent);
+
+    processTree(parent);
+
+    // Simulate re-entrancy: intercept appendChild on the boundary so that
+    // when showFallback appends the fallback wrapper, we synchronously
+    // fire a window-level error event targeting the boundary. The
+    // directive's capture-phase window error handler calls showFallback
+    // again — the _handling guard must suppress the recursive call.
+    let secondaryFired = false;
+    const origAppendChild = Element.prototype.appendChild;
+    const patchedAppendChild = function (node) {
+      const result = origAppendChild.call(this, node);
+      if (this === boundary && !secondaryFired) {
+        secondaryFired = true;
+        // Dispatch a nojs:error while showFallback is mid-execution
+        boundary.dispatchEvent(new CustomEvent('nojs:error', {
+          detail: { message: 'Secondary error inside fallback' },
+        }));
+      }
+      return result;
+    };
+    Element.prototype.appendChild = patchedAppendChild;
+
+    // Dispatch the primary error — triggers showFallback
+    boundary.dispatchEvent(new CustomEvent('nojs:error', {
+      detail: { message: 'Primary error' },
+    }));
+
+    // Restore appendChild
+    Element.prototype.appendChild = origAppendChild;
+
+    // The fallback content should be present (primary error was handled)
+    expect(boundary.querySelector('.fallback-content')).not.toBeNull();
+
+    // The secondary error must have been dispatched
+    expect(secondaryFired).toBe(true);
+
+    // _warn should have been called for the suppressed secondary error
+    // _warn() prepends "[No.JS]" as the first arg, so the message is at index 1
+    const warnCalls = warnSpy.mock.calls.filter(
+      (call) => call[1] && call[1].includes('secondary error inside fallback')
+    );
+    expect(warnCalls.length).toBe(1);
+    expect(warnCalls[0][2]).toBe('Secondary error inside fallback');
+
+    warnSpy.mockRestore();
+  });
+});

--- a/e2e/tests/tools-dropdown.spec.ts
+++ b/e2e/tests/tools-dropdown.spec.ts
@@ -1,9 +1,12 @@
 import { test, expect } from '@playwright/test';
 
 const TOOL_URLS = {
+  elements: 'https://elements.no-js.dev/',
   lsp: 'https://lsp.no-js.dev/',
   skill: 'https://github.com/ErickXavier/nojs-skill',
 };
+
+const TOOL_COUNT = 3;
 
 test.describe('Ecosystem Tools Dropdown', () => {
   test.beforeEach(async ({ page }) => {
@@ -55,10 +58,11 @@ test.describe('Ecosystem Tools Dropdown', () => {
       await expect(toolsMenu).toBeVisible();
 
       const links = toolsMenu.locator('a.tools-option');
-      await expect(links).toHaveCount(2);
+      await expect(links).toHaveCount(TOOL_COUNT);
 
-      await expect(links.nth(0)).toHaveAttribute('href', TOOL_URLS.lsp);
-      await expect(links.nth(1)).toHaveAttribute('href', TOOL_URLS.skill);
+      await expect(links.nth(0)).toHaveAttribute('href', TOOL_URLS.elements);
+      await expect(links.nth(1)).toHaveAttribute('href', TOOL_URLS.lsp);
+      await expect(links.nth(2)).toHaveAttribute('href', TOOL_URLS.skill);
     });
 
     test('4 — All links open in a new tab (target="_blank")', async ({ page }) => {
@@ -66,9 +70,9 @@ test.describe('Ecosystem Tools Dropdown', () => {
       await toolsBtn.click();
 
       const links = page.locator('#tools-menu a.tools-option');
-      await expect(links).toHaveCount(2);
+      await expect(links).toHaveCount(TOOL_COUNT);
 
-      for (let i = 0; i < 2; i++) {
+      for (let i = 0; i < TOOL_COUNT; i++) {
         await expect(links.nth(i)).toHaveAttribute('target', '_blank');
       }
     });
@@ -77,10 +81,10 @@ test.describe('Ecosystem Tools Dropdown', () => {
       await page.locator('.tools-dropdown-btn').click();
 
       const options = page.locator('#tools-menu a.tools-option');
-      await expect(options).toHaveCount(2);
+      await expect(options).toHaveCount(TOOL_COUNT);
 
       // Each option should have a non-empty name and description
-      for (let i = 0; i < 2; i++) {
+      for (let i = 0; i < TOOL_COUNT; i++) {
         const name = options.nth(i).locator('.tools-option-name');
         const desc = options.nth(i).locator('.tools-option-desc');
         await expect(name).not.toBeEmpty();
@@ -125,12 +129,15 @@ test.describe('Ecosystem Tools Dropdown', () => {
       await expect(groupLabel).toBeVisible();
 
       // Verify tool links (external links with target="_blank" inside mobile nav)
+      const elementsLink = mobileNav.locator(`a[href="${TOOL_URLS.elements}"]`);
       const lspLink = mobileNav.locator(`a[href="${TOOL_URLS.lsp}"]`);
       const skillLink = mobileNav.locator(`a[href="${TOOL_URLS.skill}"]`);
 
+      await expect(elementsLink).toBeVisible();
       await expect(lspLink).toBeVisible();
       await expect(skillLink).toBeVisible();
 
+      await expect(elementsLink).toHaveAttribute('target', '_blank');
       await expect(lspLink).toHaveAttribute('target', '_blank');
       await expect(skillLink).toHaveAttribute('target', '_blank');
     });
@@ -163,12 +170,15 @@ test.describe('Ecosystem Tools Dropdown', () => {
     test('9 — Footer contains all tool links', async ({ page }) => {
       const footer = page.locator('footer.footer');
 
+      const elementsLink = footer.locator(`a[href="${TOOL_URLS.elements}"]`);
       const lspLink = footer.locator(`a[href="${TOOL_URLS.lsp}"]`);
       const skillLink = footer.locator(`a[href="${TOOL_URLS.skill}"]`);
 
+      await expect(elementsLink).toBeVisible();
       await expect(lspLink).toBeVisible();
       await expect(skillLink).toBeVisible();
 
+      await expect(elementsLink).toHaveAttribute('target', '_blank');
       await expect(lspLink).toHaveAttribute('target', '_blank');
       await expect(skillLink).toHaveAttribute('target', '_blank');
     });
@@ -208,8 +218,9 @@ test.describe('Ecosystem Tools Dropdown', () => {
 
       // Verify descriptions are in Spanish
       const options = page.locator('#tools-menu a.tools-option');
-      await expect(options.nth(0).locator('.tools-option-desc')).toHaveText('Extensión VS Code');
-      await expect(options.nth(1).locator('.tools-option-desc')).toHaveText('Referencia AI agent');
+      await expect(options.nth(0).locator('.tools-option-desc')).toHaveText('Drag, drop y validación');
+      await expect(options.nth(1).locator('.tools-option-desc')).toHaveText('Extensión VS Code');
+      await expect(options.nth(2).locator('.tools-option-desc')).toHaveText('Referencia AI agent');
     });
   });
 });

--- a/src/directives/error-boundary.js
+++ b/src/directives/error-boundary.js
@@ -2,7 +2,7 @@
 //  DIRECTIVE: error-boundary
 // ═══════════════════════════════════════════════════════════════════════
 
-import { _onDispose } from "../globals.js";
+import { _onDispose, _warn } from "../globals.js";
 import { createContext } from "../context.js";
 import { findContext, _cloneTemplate } from "../dom.js";
 import { registerDirective, processTree, _disposeChildren } from "../registry.js";
@@ -11,22 +11,32 @@ registerDirective("error-boundary", {
   priority: 1,
   init(el, name, fallbackTpl) {
     const ctx = findContext(el);
+    let _handling = false;
 
     function showFallback(message) {
-      const clone = _cloneTemplate(fallbackTpl);
-      if (clone) {
-        const childCtx = createContext(
-          { err: { message } },
-          ctx,
-        );
-        _disposeChildren(el);
-        el.innerHTML = "";
-        const wrapper = document.createElement("div");
-        wrapper.style.display = "contents";
-        wrapper.__ctx = childCtx;
-        wrapper.appendChild(clone);
-        el.appendChild(wrapper);
-        processTree(wrapper);
+      if (_handling) {
+        _warn("error-boundary: secondary error inside fallback (suppressed to prevent infinite recursion):", message);
+        return;
+      }
+      _handling = true;
+      try {
+        const clone = _cloneTemplate(fallbackTpl);
+        if (clone) {
+          const childCtx = createContext(
+            { err: { message } },
+            ctx,
+          );
+          _disposeChildren(el);
+          el.innerHTML = "";
+          const wrapper = document.createElement("div");
+          wrapper.style.display = "contents";
+          wrapper.__ctx = childCtx;
+          wrapper.appendChild(clone);
+          el.appendChild(wrapper);
+          processTree(wrapper);
+        }
+      } finally {
+        _handling = false;
       }
     }
 


### PR DESCRIPTION
## Summary
- **GH #95**: Added re-entrancy guard (`_handling` boolean + try/finally) to `showFallback()` in `error-boundary.js` — prevents infinite recursion when a fallback template triggers an error. Secondary errors surfaced via `_warn()`.
- **GH #96**: Fixed 11 failing e2e assertions in `tools-dropdown.spec.ts` — root cause was NoJS Elements added as third tool link (`elements.no-js.dev`), shifting dropdown order. Updated `TOOL_URLS`, count assertions (2→3), index checks, mobile/footer/i18n tests.

## Branch cleanup (not in diff)
Deleted ~45 stale remote branches across Core, CLI, LSP, and Skill repos from completed/abandoned work.

## Files changed
- `src/directives/error-boundary.js` — re-entrancy guard
- `__tests__/directives-core.test.js` — unit test for boundary guard
- `e2e/tests/tools-dropdown.spec.ts` — fixture reconciliation

Closes #95, Closes #96

## Test plan
- [x] `npx jest --no-coverage __tests__/directives-core.test.js` — 176 tests pass
- [x] `npx playwright test e2e/tests/tools-dropdown.spec.ts` — 33 tests pass (Chromium, Firefox, WebKit)