### PR TITLE
fix(evaluate): intercept document.location in _safeDocument proxy

### DIFF
--- a/src/evaluate.js
+++ b/src/evaluate.js
@@ -804,10 +804,12 @@ const _safeDocument = typeof globalThis !== 'undefined' && typeof globalThis.doc
       get(target, prop, receiver) {
         if (typeof prop === 'string' && _BLOCKED_DOCUMENT_PROPS.has(prop)) return undefined;
         if (prop === 'defaultView') return _safeWindow;
+        if (prop === 'location') return _safeLocation;
         return Reflect.get(target, prop, receiver);
       },
       set(target, prop, value) {
         if (typeof prop === 'string' && _BLOCKED_DOCUMENT_PROPS.has(prop)) return true;
+        if (prop === 'location') return true;
         target[prop] = value;
         return true;
       },


### PR DESCRIPTION
## Summary

- **Security fix**: The `_safeDocument` proxy did not intercept `document.location`, allowing template expressions to access the real `Location` object with full navigation capabilities (`.assign()`, `.replace()`, `.href` setter), bypassing the `_safeLocation` read-only wrapper.
- Added `location` interception in both the `get` handler (returns `_safeLocation`) and the `set` handler (silently ignores writes), matching the existing pattern used by `_safeWindow` via `_WINDOW_PROXY_OVERRIDES`.

## Test plan

- [x] Full Jest suite passes (22 suites, 1584 tests, 0 failures)
- [x] Build succeeds (`node build.js`)
- [ ] Verify `document.location.assign()` is a no-op in a template expression
- [ ] Verify `document.location.href` returns the read-only value from `_safeLocation`
- [ ] Verify setting `document.location` in a template expression is silently ignored