### PR TITLE
fix(conditionals): count consecutive backslashes in _splitTopLevel escape detection

### DIFF
--- a/__tests__/directives-core.test.js
+++ b/__tests__/directives-core.test.js
@@ -997,6 +997,22 @@ describe('switch with default', () => {
     expect(document.getElementById('c').style.display).toBe('none');
   });
 
+  test('BUG: multi-value case with escaped backslash', () => {
+    const parent = document.createElement('div');
+    parent.setAttribute('state', '{ val: "b" }');
+    parent.innerHTML = `
+      <div switch="val">
+        <div case="'a\\\\\\\\','b'" id="ab">A or B</div>
+        <div case="'c'" id="c">C</div>
+      </div>
+    `;
+    document.body.appendChild(parent);
+    processTree(parent);
+
+    expect(document.getElementById('ab').style.display).toBe('');
+    expect(document.getElementById('c').style.display).toBe('none');
+  });
+
   test('switch with then template in case', () => {
     const tpl = document.createElement('template');
     tpl.id = 'case-tpl';

--- a/src/directives/conditionals.js
+++ b/src/directives/conditionals.js
@@ -292,7 +292,11 @@ function _splitTopLevel(str) {
   for (let i = 0; i < str.length; i++) {
     const ch = str[i];
     if (quote) {
-      if (ch === quote && str[i - 1] !== "\\") quote = null;
+      if (ch === quote) {
+        let bs = 0;
+        for (let j = i - 1; j >= 0 && str[j] === "\\"; j--) bs++;
+        if (bs % 2 === 0) quote = null;
+      }
     } else if (ch === "'" || ch === '"' || ch === "`") {
       quote = ch;
     } else if (ch === "(" || ch === "[" || ch === "{") {


### PR DESCRIPTION
## Summary
- Fixes `_splitTopLevel` in `src/directives/conditionals.js` where the escape detection at line 295 only checked the single preceding character (`str[i - 1] !== "\\"`) to determine if a quote was escaped. This failed when the preceding character was itself an escaped backslash (e.g. `'a\\\\','b'`), making the second value after the comma unreachable in multi-value `switch` `case` attributes.
- Replaced the single-char check with a backslash-counting loop that counts consecutive backslashes before the quote character and uses modulo-2 parity to determine if the quote is truly escaped. This matches the existing pattern already used in `src/evaluate.js:1270-1273`.
- Added a regression test `BUG: multi-value case with escaped backslash` in `__tests__/directives-core.test.js`.

## Test plan
- [x] New test `BUG: multi-value case with escaped backslash` passes
- [x] Full Jest suite passes (1585 tests, 0 failures)
- [x] Build succeeds

Closes NOJS-94