### PR TITLE
feat(docs): add pagination i18n translations (PT/ES/FR/IT)

### DIFF
--- a/docs/locales/es/docs.json
+++ b/docs/locales/es/docs.json
@@ -1607,6 +1607,119 @@
         "captureTitle": "Captura de Template JSON-LD",
         "captureText": "El innerHTML del elemento page-jsonld se captura en el momento del procesamiento. Si necesitas JSON-LD reactivo, coloca el elemento dentro de un scope de state y usa interpolación {expresión}."
       }
+    },
+    "pagination": {
+      "hero": {
+        "badge": "Guía",
+        "title": "Paginación y Triggers",
+        "subtitle": "Infinite scroll declarativo, botones de load more, lazy loading y paginación basada en cursor — todo con atributos HTML."
+      },
+      "quickStart": {
+        "title": "Inicio Rápido",
+        "text": "Añade get-trigger y get-insert a cualquier directiva get para habilitar la paginación. Aquí tienes un ejemplo mínimo de infinite scroll:",
+        "note": "La directiva get obtiene la página 1 al cargar. Cuando el usuario hace scroll cerca del final, obtiene automáticamente la siguiente página y añade los nuevos elementos."
+      },
+      "attributes": {
+        "title": "Referencia de Atributos",
+        "col1": "Atributo",
+        "col2": "Valores",
+        "col3": "Por defecto",
+        "col4": "Descripción",
+        "getInsert": "Controla dónde se coloca el nuevo contenido respecto al contenido existente. Sin este atributo, el contenido obtenido reemplaza el contenido actual por completo.",
+        "getTrigger": "Controla cuándo se dispara el fetch. Sin este atributo, el fetch se dispara inmediatamente al montar.",
+        "getPage": "Número de página inicial para paginación basada en offset. La variable de contexto page se incrementa automáticamente tras cada fetch exitoso.",
+        "getCursor": "Habilita paginación basada en cursor. El cursor se extrae del header de respuesta (X-Cursor) o del campo del cuerpo JSON.",
+        "getCursorField": "Ruta personalizada del campo JSON para la extracción del cursor usando notación de punto (ej. pagination.nextToken). Sin esto, No.JS busca cursor, next_cursor, nextCursor, next.",
+        "getThreshold": "rootMargin del IntersectionObserver. Controla cuán temprano se dispara el fetch antes de que el elemento entre en el viewport.",
+        "getTriggerLabel": "Texto personalizado para el botón de load more generado automáticamente al usar get-trigger=\"button\"."
+      },
+      "examples": {
+        "title": "Ejemplos en Vivo",
+        "infiniteScroll": {
+          "title": "Infinite Scroll",
+          "desc": "Carga automáticamente la siguiente página cuando el usuario hace scroll cerca del final de la lista.",
+          "label": "Resultado en Vivo"
+        },
+        "loadMore": {
+          "title": "Botón Load More",
+          "desc": "Muestra un botón que el usuario pulsa para cargar la siguiente página de resultados.",
+          "label": "Resultado en Vivo"
+        },
+        "lazyLoad": {
+          "title": "Lazy Load al Ser Visible",
+          "desc": "El contenido se obtiene solo cuando el elemento entra en el viewport al hacer scroll. Ideal para secciones debajo del pliegue.",
+          "label": "Resultado en Vivo"
+        },
+        "hoverPrefetch": {
+          "title": "Hover Prefetch",
+          "desc": "El contenido se obtiene en el primer evento mouseenter. Útil para tooltips y tarjetas de vista previa.",
+          "label": "Resultado en Vivo",
+          "hoverMe": "Pasa el ratón sobre esta tarjeta para cargar el contenido de vista previa"
+        },
+        "programmatic": {
+          "title": "Fetch Programático",
+          "desc": "El fetch no se dispara automáticamente. Usa $refs para dispararlo manualmente mediante un botón u otro evento.",
+          "label": "Resultado en Vivo",
+          "clickToLoad": "Haz clic en el botón para disparar el fetch manualmente."
+        },
+        "cursorPagination": {
+          "title": "Cursor Pagination",
+          "desc": "Usa paginación basada en cursor en lugar de números de página. El cursor se extrae del cuerpo de la respuesta JSON.",
+          "label": "Resultado en Vivo"
+        },
+        "liveFeed": {
+          "title": "Live Feed (Prepend)",
+          "desc": "El nuevo contenido se inserta en la parte superior de la lista, simulando un feed en vivo o un ticker de noticias.",
+          "label": "Resultado en Vivo",
+          "loadNewer": "Cargar Más Recientes"
+        }
+      },
+      "matrix": {
+        "title": "Matriz de Composición",
+        "text": "Los atributos get-trigger y get-insert se combinan para formar una matriz 5x3 de comportamientos. Así funciona cada combinación:",
+        "col1": "Trigger",
+        "col2": "Sin insert (replace)",
+        "col3": "append",
+        "col4": "prepend",
+        "immediateReplace": "Comportamiento por defecto — el fetch reemplaza el contenido al montar.",
+        "immediateAppend": "Fetch al montar, añade el resultado debajo del contenido existente.",
+        "immediatePrepend": "Fetch al montar, inserta el resultado encima del contenido existente.",
+        "scrollReplace": "Vuelve al comportamiento visible (scroll requiere modo de insert).",
+        "scrollAppend": "Infinite scroll — añade nuevas páginas conforme el usuario hace scroll hacia abajo.",
+        "scrollPrepend": "Infinite scroll — inserta nuevas páginas conforme el usuario hace scroll hacia arriba.",
+        "buttonReplace": "Vuelve al comportamiento immediate (button requiere modo de insert).",
+        "buttonAppend": "Botón load more — añade la siguiente página al hacer clic.",
+        "buttonPrepend": "Botón load more — inserta la siguiente página al hacer clic.",
+        "visibleReplace": "Lazy load — obtiene y reemplaza el contenido cuando el elemento entra en el viewport.",
+        "visibleAppend": "Lazy load — obtiene y añade el contenido cuando el elemento entra en el viewport.",
+        "visiblePrepend": "Lazy load — obtiene e inserta el contenido cuando el elemento entra en el viewport.",
+        "hoverReplace": "Prefetch — obtiene y reemplaza el contenido en el primer mouseenter.",
+        "hoverAppend": "Prefetch — obtiene y añade el contenido en el primer mouseenter.",
+        "hoverPrepend": "Prefetch — obtiene e inserta el contenido en el primer mouseenter.",
+        "noneReplace": "Manual — sin auto-fetch, usa $refs.refresh() para disparar.",
+        "noneAppend": "Manual — sin auto-fetch, $refs.refresh() añade.",
+        "nonePrepend": "Manual — sin auto-fetch, $refs.refresh() inserta."
+      },
+      "endOfData": {
+        "title": "Detección de Fin de Datos",
+        "text": "No.JS detecta el fin de los datos paginados de tres formas, dependiendo del formato de la respuesta:",
+        "emptyBody": "Cuerpo de respuesta vacío",
+        "emptyBodyText": "Cuando el servidor devuelve un cuerpo de respuesta vacío (Content-Length: 0 o cadena vacía), No.JS detiene la paginación y oculta el botón de load more.",
+        "lastPageHeader": "Header X-NoJS-Last-Page",
+        "lastPageHeaderText": "El servidor puede enviar un header de respuesta X-NoJS-Last-Page: true para señalar explícitamente que no hay más páginas.",
+        "nullCursor": "Cursor nulo",
+        "nullCursorText": "Para paginación basada en cursor, cuando el campo del cursor en la respuesta JSON es nulo o está ausente, No.JS detiene la paginación."
+      },
+      "templates": {
+        "title": "Templates con Paginación",
+        "text": "Los templates de loading, error y empty funcionan perfectamente con la paginación. El template de loading se muestra durante cada fetch de página, y el template de error se muestra si alguna página falla.",
+        "loadingNote": "Durante la paginación (no en el primer fetch), se muestra un pequeño indicador de loading inline en el borde de inserción en lugar de reemplazar todo el contenido.",
+        "emptyNote": "El template de empty solo se muestra cuando la primera página no devuelve datos. Las páginas posteriores vacías simplemente detienen la paginación."
+      },
+      "scrollPosition": {
+        "title": "Preservación de la Posición de Scroll",
+        "text": "Al usar get-insert=\"prepend\", No.JS preserva automáticamente la posición de scroll del usuario. El nuevo contenido se inserta encima del viewport actual, y el offset de scroll se ajusta para que la vista del usuario no salte."
+      }
     }
   }
 }

--- a/docs/locales/es/shell.json
+++ b/docs/locales/es/shell.json
@@ -40,6 +40,7 @@
       "loops": "Bucles",
       "templates": "Plantillas",
       "fetchApi": "Fetch y API",
+      "pagination": "Paginación y Triggers",
       "routing": "Enrutamiento",
       "headManagement": "Gestión del Head",
       "forms": "Formularios",

--- a/docs/locales/fr/docs.json
+++ b/docs/locales/fr/docs.json
@@ -1607,6 +1607,119 @@
         "captureTitle": "Capture du Template JSON-LD",
         "captureText": "Le innerHTML de l'élément page-jsonld est capturé au moment du traitement. Si vous avez besoin de JSON-LD réactif, placez l'élément à l'intérieur d'un scope de state et utilisez l'interpolation {expression}."
       }
+    },
+    "pagination": {
+      "hero": {
+        "badge": "Guide",
+        "title": "Pagination et Déclencheurs",
+        "subtitle": "Infinite scroll déclaratif, boutons load more, lazy loading et pagination basée sur un cursor — le tout avec des attributs HTML."
+      },
+      "quickStart": {
+        "title": "Démarrage Rapide",
+        "text": "Ajoutez get-trigger et get-insert à n'importe quelle directive get pour activer la pagination. Voici un exemple minimal d'infinite scroll :",
+        "note": "La directive get récupère la page 1 au chargement. Lorsque l'utilisateur fait défiler près du bas, elle récupère automatiquement la page suivante et ajoute les nouveaux éléments."
+      },
+      "attributes": {
+        "title": "Référence des Attributs",
+        "col1": "Attribut",
+        "col2": "Valeurs",
+        "col3": "Par défaut",
+        "col4": "Description",
+        "getInsert": "Contrôle où le nouveau contenu est placé par rapport au contenu existant. Sans cet attribut, le contenu récupéré remplace entièrement le contenu actuel.",
+        "getTrigger": "Contrôle quand le fetch est déclenché. Sans cet attribut, le fetch se déclenche immédiatement au montage.",
+        "getPage": "Numéro de page initial pour la pagination basée sur l'offset. La variable de contexte page s'incrémente automatiquement après chaque fetch réussi.",
+        "getCursor": "Active la pagination basée sur un cursor. Le cursor est extrait de l'en-tête de réponse (X-Cursor) ou du champ du corps JSON.",
+        "getCursorField": "Chemin personnalisé du champ JSON pour l'extraction du cursor en notation par points (ex. pagination.nextToken). Sans cela, No.JS recherche cursor, next_cursor, nextCursor, next.",
+        "getThreshold": "rootMargin de l'IntersectionObserver. Contrôle à quel point le fetch se déclenche tôt avant que l'élément n'entre dans le viewport.",
+        "getTriggerLabel": "Texte personnalisé pour le bouton load more généré automatiquement lors de l'utilisation de get-trigger=\"button\"."
+      },
+      "examples": {
+        "title": "Exemples en Direct",
+        "infiniteScroll": {
+          "title": "Infinite Scroll",
+          "desc": "Charge automatiquement la page suivante lorsque l'utilisateur fait défiler près du bas de la liste.",
+          "label": "Résultat en Direct"
+        },
+        "loadMore": {
+          "title": "Bouton Load More",
+          "desc": "Affiche un bouton sur lequel l'utilisateur clique pour charger la page suivante de résultats.",
+          "label": "Résultat en Direct"
+        },
+        "lazyLoad": {
+          "title": "Lazy Load au Défilement",
+          "desc": "Le contenu est récupéré uniquement lorsque l'élément entre dans le viewport par défilement. Idéal pour les sections sous la ligne de flottaison.",
+          "label": "Résultat en Direct"
+        },
+        "hoverPrefetch": {
+          "title": "Hover Prefetch",
+          "desc": "Le contenu est récupéré au premier événement mouseenter. Utile pour les tooltips et les cartes de prévisualisation.",
+          "label": "Résultat en Direct",
+          "hoverMe": "Survolez cette carte pour charger le contenu de prévisualisation"
+        },
+        "programmatic": {
+          "title": "Fetch Programmatique",
+          "desc": "Le fetch ne se déclenche pas automatiquement. Utilisez $refs pour le déclencher manuellement via un bouton ou un autre événement.",
+          "label": "Résultat en Direct",
+          "clickToLoad": "Cliquez sur le bouton pour déclencher le fetch manuellement."
+        },
+        "cursorPagination": {
+          "title": "Cursor Pagination",
+          "desc": "Utilise la pagination basée sur un cursor au lieu des numéros de page. Le cursor est extrait du corps de la réponse JSON.",
+          "label": "Résultat en Direct"
+        },
+        "liveFeed": {
+          "title": "Live Feed (Prepend)",
+          "desc": "Le nouveau contenu est inséré en haut de la liste, simulant un flux en direct ou un défileur d'actualités.",
+          "label": "Résultat en Direct",
+          "loadNewer": "Charger les Plus Récents"
+        }
+      },
+      "matrix": {
+        "title": "Matrice de Composition",
+        "text": "Les attributs get-trigger et get-insert se combinent pour former une matrice 5x3 de comportements. Voici comment chaque combinaison fonctionne :",
+        "col1": "Trigger",
+        "col2": "Sans insert (replace)",
+        "col3": "append",
+        "col4": "prepend",
+        "immediateReplace": "Comportement par défaut — le fetch remplace le contenu au montage.",
+        "immediateAppend": "Fetch au montage, ajoute le résultat sous le contenu existant.",
+        "immediatePrepend": "Fetch au montage, insère le résultat au-dessus du contenu existant.",
+        "scrollReplace": "Revient au comportement visible (scroll nécessite le mode insert).",
+        "scrollAppend": "Infinite scroll — ajoute de nouvelles pages au fur et à mesure que l'utilisateur défile vers le bas.",
+        "scrollPrepend": "Infinite scroll — insère de nouvelles pages au fur et à mesure que l'utilisateur défile vers le haut.",
+        "buttonReplace": "Revient au comportement immediate (button nécessite le mode insert).",
+        "buttonAppend": "Bouton load more — ajoute la page suivante au clic.",
+        "buttonPrepend": "Bouton load more — insère la page suivante au clic.",
+        "visibleReplace": "Lazy load — récupère et remplace le contenu lorsque l'élément entre dans le viewport.",
+        "visibleAppend": "Lazy load — récupère et ajoute le contenu lorsque l'élément entre dans le viewport.",
+        "visiblePrepend": "Lazy load — récupère et insère le contenu lorsque l'élément entre dans le viewport.",
+        "hoverReplace": "Prefetch — récupère et remplace le contenu au premier mouseenter.",
+        "hoverAppend": "Prefetch — récupère et ajoute le contenu au premier mouseenter.",
+        "hoverPrepend": "Prefetch — récupère et insère le contenu au premier mouseenter.",
+        "noneReplace": "Manuel — pas d'auto-fetch, utilisez $refs.refresh() pour déclencher.",
+        "noneAppend": "Manuel — pas d'auto-fetch, $refs.refresh() ajoute.",
+        "nonePrepend": "Manuel — pas d'auto-fetch, $refs.refresh() insère."
+      },
+      "endOfData": {
+        "title": "Détection de Fin de Données",
+        "text": "No.JS détecte la fin des données paginées de trois manières, selon le format de la réponse :",
+        "emptyBody": "Corps de réponse vide",
+        "emptyBodyText": "Lorsque le serveur renvoie un corps de réponse vide (Content-Length: 0 ou chaîne vide), No.JS arrête la pagination et masque le bouton load more.",
+        "lastPageHeader": "En-tête X-NoJS-Last-Page",
+        "lastPageHeaderText": "Le serveur peut envoyer un en-tête de réponse X-NoJS-Last-Page: true pour signaler explicitement qu'il n'y a plus de pages.",
+        "nullCursor": "Cursor nul",
+        "nullCursorText": "Pour la pagination basée sur un cursor, lorsque le champ du cursor dans la réponse JSON est nul ou absent, No.JS arrête la pagination."
+      },
+      "templates": {
+        "title": "Templates avec Pagination",
+        "text": "Les templates de loading, error et empty fonctionnent parfaitement avec la pagination. Le template de loading est affiché pendant chaque fetch de page, et le template d'error est affiché si une page échoue.",
+        "loadingNote": "Pendant la pagination (pas lors du premier fetch), un petit indicateur de loading inline est affiché au bord d'insertion au lieu de remplacer tout le contenu.",
+        "emptyNote": "Le template empty n'est affiché que lorsque la première page ne renvoie aucune donnée. Les pages suivantes vides arrêtent simplement la pagination."
+      },
+      "scrollPosition": {
+        "title": "Préservation de la Position de Scroll",
+        "text": "Lors de l'utilisation de get-insert=\"prepend\", No.JS préserve automatiquement la position de scroll de l'utilisateur. Le nouveau contenu est inséré au-dessus du viewport actuel, et l'offset de scroll est ajusté pour que la vue de l'utilisateur ne saute pas."
+      }
     }
   }
 }

--- a/docs/locales/fr/shell.json
+++ b/docs/locales/fr/shell.json
@@ -40,6 +40,7 @@
       "loops": "Boucles",
       "templates": "Templates",
       "fetchApi": "Fetch & API",
+      "pagination": "Pagination et Déclencheurs",
       "routing": "Routage",
       "headManagement": "Gestion du head",
       "forms": "Formulaires",

--- a/docs/locales/it/docs.json
+++ b/docs/locales/it/docs.json
@@ -1607,6 +1607,119 @@
         "captureTitle": "Cattura del Template JSON-LD",
         "captureText": "L'innerHTML dell'elemento page-jsonld viene catturato al momento dell'elaborazione. Se hai bisogno di JSON-LD reattivo, posiziona l'elemento all'interno di uno scope di state e usa l'interpolazione {espressione}."
       }
+    },
+    "pagination": {
+      "hero": {
+        "badge": "Guida",
+        "title": "Paginazione e Trigger",
+        "subtitle": "Infinite scroll dichiarativo, pulsanti load more, lazy loading e paginazione basata su cursor — tutto con attributi HTML."
+      },
+      "quickStart": {
+        "title": "Avvio Rapido",
+        "text": "Aggiungi get-trigger e get-insert a qualsiasi direttiva get per abilitare la paginazione. Ecco un esempio minimo di infinite scroll:",
+        "note": "La direttiva get recupera la pagina 1 al caricamento. Quando l'utente fa scroll vicino alla fine, recupera automaticamente la pagina successiva e aggiunge i nuovi elementi."
+      },
+      "attributes": {
+        "title": "Riferimento Attributi",
+        "col1": "Attributo",
+        "col2": "Valori",
+        "col3": "Predefinito",
+        "col4": "Descrizione",
+        "getInsert": "Controlla dove il nuovo contenuto viene posizionato rispetto al contenuto esistente. Senza questo attributo, il contenuto recuperato sostituisce interamente il contenuto attuale.",
+        "getTrigger": "Controlla quando il fetch viene attivato. Senza questo attributo, il fetch viene attivato immediatamente al montaggio.",
+        "getPage": "Numero di pagina iniziale per la paginazione basata su offset. La variabile di contesto page si incrementa automaticamente dopo ogni fetch riuscito.",
+        "getCursor": "Abilita la paginazione basata su cursor. Il cursor viene estratto dall'header di risposta (X-Cursor) o dal campo del corpo JSON.",
+        "getCursorField": "Percorso personalizzato del campo JSON per l'estrazione del cursor usando la notazione a punti (es. pagination.nextToken). Senza questo, No.JS cerca cursor, next_cursor, nextCursor, next.",
+        "getThreshold": "rootMargin dell'IntersectionObserver. Controlla quanto in anticipo il fetch viene attivato prima che l'elemento entri nel viewport.",
+        "getTriggerLabel": "Testo personalizzato per il pulsante load more generato automaticamente quando si usa get-trigger=\"button\"."
+      },
+      "examples": {
+        "title": "Esempi dal Vivo",
+        "infiniteScroll": {
+          "title": "Infinite Scroll",
+          "desc": "Carica automaticamente la pagina successiva quando l'utente fa scroll vicino alla fine della lista.",
+          "label": "Risultato dal Vivo"
+        },
+        "loadMore": {
+          "title": "Pulsante Load More",
+          "desc": "Mostra un pulsante che l'utente clicca per caricare la pagina successiva di risultati.",
+          "label": "Risultato dal Vivo"
+        },
+        "lazyLoad": {
+          "title": "Lazy Load alla Visibilità",
+          "desc": "Il contenuto viene recuperato solo quando l'elemento entra nel viewport tramite scroll. Ideale per le sezioni sotto la piega.",
+          "label": "Risultato dal Vivo"
+        },
+        "hoverPrefetch": {
+          "title": "Hover Prefetch",
+          "desc": "Il contenuto viene recuperato al primo evento mouseenter. Utile per tooltip e card di anteprima.",
+          "label": "Risultato dal Vivo",
+          "hoverMe": "Passa il mouse su questa card per caricare il contenuto di anteprima"
+        },
+        "programmatic": {
+          "title": "Fetch Programmatico",
+          "desc": "Il fetch non viene attivato automaticamente. Usa $refs per attivarlo manualmente tramite un pulsante o un altro evento.",
+          "label": "Risultato dal Vivo",
+          "clickToLoad": "Clicca il pulsante per attivare il fetch manualmente."
+        },
+        "cursorPagination": {
+          "title": "Cursor Pagination",
+          "desc": "Usa la paginazione basata su cursor invece dei numeri di pagina. Il cursor viene estratto dal corpo della risposta JSON.",
+          "label": "Risultato dal Vivo"
+        },
+        "liveFeed": {
+          "title": "Live Feed (Prepend)",
+          "desc": "Il nuovo contenuto viene inserito in cima alla lista, simulando un feed dal vivo o un ticker di notizie.",
+          "label": "Risultato dal Vivo",
+          "loadNewer": "Carica Più Recenti"
+        }
+      },
+      "matrix": {
+        "title": "Matrice di Composizione",
+        "text": "Gli attributi get-trigger e get-insert si combinano per formare una matrice 5x3 di comportamenti. Ecco come funziona ogni combinazione:",
+        "col1": "Trigger",
+        "col2": "Senza insert (replace)",
+        "col3": "append",
+        "col4": "prepend",
+        "immediateReplace": "Comportamento predefinito — il fetch sostituisce il contenuto al montaggio.",
+        "immediateAppend": "Fetch al montaggio, aggiunge il risultato sotto il contenuto esistente.",
+        "immediatePrepend": "Fetch al montaggio, inserisce il risultato sopra il contenuto esistente.",
+        "scrollReplace": "Torna al comportamento visible (scroll richiede la modalità insert).",
+        "scrollAppend": "Infinite scroll — aggiunge nuove pagine man mano che l'utente fa scroll verso il basso.",
+        "scrollPrepend": "Infinite scroll — inserisce nuove pagine man mano che l'utente fa scroll verso l'alto.",
+        "buttonReplace": "Torna al comportamento immediate (button richiede la modalità insert).",
+        "buttonAppend": "Pulsante load more — aggiunge la pagina successiva al clic.",
+        "buttonPrepend": "Pulsante load more — inserisce la pagina successiva al clic.",
+        "visibleReplace": "Lazy load — recupera e sostituisce il contenuto quando l'elemento entra nel viewport.",
+        "visibleAppend": "Lazy load — recupera e aggiunge il contenuto quando l'elemento entra nel viewport.",
+        "visiblePrepend": "Lazy load — recupera e inserisce il contenuto quando l'elemento entra nel viewport.",
+        "hoverReplace": "Prefetch — recupera e sostituisce il contenuto al primo mouseenter.",
+        "hoverAppend": "Prefetch — recupera e aggiunge il contenuto al primo mouseenter.",
+        "hoverPrepend": "Prefetch — recupera e inserisce il contenuto al primo mouseenter.",
+        "noneReplace": "Manuale — nessun auto-fetch, usa $refs.refresh() per attivare.",
+        "noneAppend": "Manuale — nessun auto-fetch, $refs.refresh() aggiunge.",
+        "nonePrepend": "Manuale — nessun auto-fetch, $refs.refresh() inserisce."
+      },
+      "endOfData": {
+        "title": "Rilevamento Fine Dati",
+        "text": "No.JS rileva la fine dei dati paginati in tre modi, a seconda del formato della risposta:",
+        "emptyBody": "Corpo della risposta vuoto",
+        "emptyBodyText": "Quando il server restituisce un corpo di risposta vuoto (Content-Length: 0 o stringa vuota), No.JS interrompe la paginazione e nasconde il pulsante load more.",
+        "lastPageHeader": "Header X-NoJS-Last-Page",
+        "lastPageHeaderText": "Il server può inviare un header di risposta X-NoJS-Last-Page: true per segnalare esplicitamente che non ci sono più pagine.",
+        "nullCursor": "Cursor nullo",
+        "nullCursorText": "Per la paginazione basata su cursor, quando il campo del cursor nella risposta JSON è nullo o assente, No.JS interrompe la paginazione."
+      },
+      "templates": {
+        "title": "Template con Paginazione",
+        "text": "I template di loading, error ed empty funzionano perfettamente con la paginazione. Il template di loading viene mostrato durante ogni fetch di pagina, e il template di error viene mostrato se una pagina fallisce.",
+        "loadingNote": "Durante la paginazione (non al primo fetch), un piccolo indicatore di loading inline viene mostrato al bordo di inserimento invece di sostituire tutto il contenuto.",
+        "emptyNote": "Il template empty viene mostrato solo quando la prima pagina non restituisce dati. Le pagine successive vuote semplicemente interrompono la paginazione."
+      },
+      "scrollPosition": {
+        "title": "Preservazione della Posizione di Scroll",
+        "text": "Quando si usa get-insert=\"prepend\", No.JS preserva automaticamente la posizione di scroll dell'utente. Il nuovo contenuto viene inserito sopra il viewport attuale, e l'offset di scroll viene regolato in modo che la vista dell'utente non salti."
+      }
     }
   }
 }

--- a/docs/locales/it/shell.json
+++ b/docs/locales/it/shell.json
@@ -40,6 +40,7 @@
       "loops": "Cicli",
       "templates": "Template",
       "fetchApi": "Fetch & API",
+      "pagination": "Paginazione e Trigger",
       "routing": "Routing",
       "headManagement": "Gestione del head",
       "forms": "Form",

--- a/docs/locales/pt/docs.json
+++ b/docs/locales/pt/docs.json
@@ -1607,6 +1607,119 @@
         "captureTitle": "Captura de Template JSON-LD",
         "captureText": "O innerHTML do elemento page-jsonld é capturado no momento do processamento. Se você precisar de JSON-LD reativo, coloque o elemento dentro de um scope de state e use interpolação {expressão}."
       }
+    },
+    "pagination": {
+      "hero": {
+        "badge": "Guia",
+        "title": "Pagination & Triggers",
+        "subtitle": "Infinite scroll declarativo, botões de load more, lazy loading e paginação baseada em cursor — tudo com atributos HTML."
+      },
+      "quickStart": {
+        "title": "Início Rápido",
+        "text": "Adicione get-trigger e get-insert a qualquer diretiva get para habilitar paginação. Aqui está um exemplo mínimo de infinite scroll:",
+        "note": "A diretiva get busca a página 1 ao carregar. Quando o usuário faz scroll perto do final, ela busca automaticamente a próxima página e faz append dos novos itens."
+      },
+      "attributes": {
+        "title": "Referência de Atributos",
+        "col1": "Atributo",
+        "col2": "Valores",
+        "col3": "Padrão",
+        "col4": "Descrição",
+        "getInsert": "Controla onde o novo conteúdo é posicionado em relação ao conteúdo existente. Sem este atributo, o conteúdo buscado substitui o conteúdo atual inteiramente.",
+        "getTrigger": "Controla quando o fetch é disparado. Sem este atributo, o fetch é disparado imediatamente ao montar.",
+        "getPage": "Número da página inicial para paginação baseada em offset. A variável de contexto page incrementa automaticamente após cada fetch bem-sucedido.",
+        "getCursor": "Habilita paginação baseada em cursor. O cursor é extraído do header de resposta (X-Cursor) ou do campo do corpo JSON.",
+        "getCursorField": "Caminho personalizado do campo JSON para extração do cursor usando notação de ponto (ex. pagination.nextToken). Sem isso, No.JS busca cursor, next_cursor, nextCursor, next.",
+        "getThreshold": "rootMargin do IntersectionObserver. Controla quão cedo o fetch é disparado antes do elemento entrar no viewport.",
+        "getTriggerLabel": "Texto personalizado para o botão de load more gerado automaticamente ao usar get-trigger=\"button\"."
+      },
+      "examples": {
+        "title": "Exemplos ao Vivo",
+        "infiniteScroll": {
+          "title": "Infinite Scroll",
+          "desc": "Carrega automaticamente a próxima página quando o usuário faz scroll perto do final da lista.",
+          "label": "Resultado ao Vivo"
+        },
+        "loadMore": {
+          "title": "Botão Load More",
+          "desc": "Exibe um botão que o usuário clica para carregar a próxima página de resultados.",
+          "label": "Resultado ao Vivo"
+        },
+        "lazyLoad": {
+          "title": "Lazy Load ao Ficar Visível",
+          "desc": "O conteúdo é buscado apenas quando o elemento entra no viewport via scroll. Ideal para seções abaixo da dobra.",
+          "label": "Resultado ao Vivo"
+        },
+        "hoverPrefetch": {
+          "title": "Hover Prefetch",
+          "desc": "O conteúdo é buscado no primeiro evento mouseenter. Útil para tooltips e cards de preview.",
+          "label": "Resultado ao Vivo",
+          "hoverMe": "Passe o mouse sobre este card para carregar o conteúdo de preview"
+        },
+        "programmatic": {
+          "title": "Fetch Programático",
+          "desc": "O fetch não é disparado automaticamente. Use $refs para dispará-lo manualmente via botão ou outro evento.",
+          "label": "Resultado ao Vivo",
+          "clickToLoad": "Clique no botão para disparar o fetch manualmente."
+        },
+        "cursorPagination": {
+          "title": "Cursor Pagination",
+          "desc": "Usa paginação baseada em cursor em vez de números de página. O cursor é extraído do corpo da resposta JSON.",
+          "label": "Resultado ao Vivo"
+        },
+        "liveFeed": {
+          "title": "Live Feed (Prepend)",
+          "desc": "Novo conteúdo é inserido no topo da lista, simulando um feed ao vivo ou ticker de notícias.",
+          "label": "Resultado ao Vivo",
+          "loadNewer": "Carregar Mais Recentes"
+        }
+      },
+      "matrix": {
+        "title": "Matriz de Composição",
+        "text": "Os atributos get-trigger e get-insert se combinam para formar uma matriz 5x3 de comportamentos. Veja como cada combinação funciona:",
+        "col1": "Trigger",
+        "col2": "Sem insert (replace)",
+        "col3": "append",
+        "col4": "prepend",
+        "immediateReplace": "Comportamento padrão — fetch substitui o conteúdo ao montar.",
+        "immediateAppend": "Fetch ao montar, faz append do resultado abaixo do conteúdo existente.",
+        "immediatePrepend": "Fetch ao montar, faz prepend do resultado acima do conteúdo existente.",
+        "scrollReplace": "Volta ao comportamento visible (scroll requer modo de insert).",
+        "scrollAppend": "Infinite scroll — faz append de novas páginas conforme o usuário faz scroll para baixo.",
+        "scrollPrepend": "Infinite scroll — faz prepend de novas páginas conforme o usuário faz scroll para cima.",
+        "buttonReplace": "Volta ao comportamento immediate (button requer modo de insert).",
+        "buttonAppend": "Botão load more — faz append da próxima página ao clicar.",
+        "buttonPrepend": "Botão load more — faz prepend da próxima página ao clicar.",
+        "visibleReplace": "Lazy load — busca e substitui o conteúdo quando o elemento entra no viewport.",
+        "visibleAppend": "Lazy load — busca e faz append do conteúdo quando o elemento entra no viewport.",
+        "visiblePrepend": "Lazy load — busca e faz prepend do conteúdo quando o elemento entra no viewport.",
+        "hoverReplace": "Prefetch — busca e substitui o conteúdo no primeiro mouseenter.",
+        "hoverAppend": "Prefetch — busca e faz append do conteúdo no primeiro mouseenter.",
+        "hoverPrepend": "Prefetch — busca e faz prepend do conteúdo no primeiro mouseenter.",
+        "noneReplace": "Manual — sem auto-fetch, use $refs.refresh() para disparar.",
+        "noneAppend": "Manual — sem auto-fetch, $refs.refresh() faz append.",
+        "nonePrepend": "Manual — sem auto-fetch, $refs.refresh() faz prepend."
+      },
+      "endOfData": {
+        "title": "Detecção de Fim de Dados",
+        "text": "No.JS detecta o fim dos dados paginados de três formas, dependendo do formato da resposta:",
+        "emptyBody": "Corpo da resposta vazio",
+        "emptyBodyText": "Quando o servidor retorna um corpo de resposta vazio (Content-Length: 0 ou string vazia), No.JS para a paginação e esconde o botão de load more.",
+        "lastPageHeader": "Header X-NoJS-Last-Page",
+        "lastPageHeaderText": "O servidor pode enviar um header de resposta X-NoJS-Last-Page: true para sinalizar explicitamente que não há mais páginas.",
+        "nullCursor": "Cursor nulo",
+        "nullCursorText": "Para paginação baseada em cursor, quando o campo do cursor na resposta JSON é nulo ou ausente, No.JS para a paginação."
+      },
+      "templates": {
+        "title": "Templates com Paginação",
+        "text": "Templates de loading, error e empty funcionam perfeitamente com paginação. O template de loading é exibido durante cada fetch de página, e o template de error é exibido se alguma página falhar.",
+        "loadingNote": "Durante a paginação (não no primeiro fetch), um pequeno indicador de loading inline é exibido na borda de inserção em vez de substituir todo o conteúdo.",
+        "emptyNote": "O template de empty só é exibido quando a primeira página não retorna dados. Páginas subsequentes vazias simplesmente param a paginação."
+      },
+      "scrollPosition": {
+        "title": "Preservação da Posição de Scroll",
+        "text": "Ao usar get-insert=\"prepend\", No.JS preserva automaticamente a posição de scroll do usuário. Novo conteúdo é inserido acima do viewport atual, e o offset de scroll é ajustado para que a visualização do usuário não pule."
+      }
     }
   }
 }

--- a/docs/locales/pt/shell.json
+++ b/docs/locales/pt/shell.json
@@ -40,6 +40,7 @@
       "loops": "Loops",
       "templates": "Templates",
       "fetchApi": "Fetch & API",
+      "pagination": "Pagination & Triggers",
       "routing": "Roteamento",
       "headManagement": "Gerenciamento de head",
       "forms": "Formulários",


### PR DESCRIPTION
## Summary

- Add `docs.pagination` section (96 keys matching EN structure exactly) to PT, ES, FR, and IT locale `docs.json` files
- Add `shell.sidebar.pagination` key to all 4 locale `shell.json` files
- PT keeps English technical terms (infinite scroll, cursor, trigger, load more, append, prepend, viewport, rootMargin, IntersectionObserver, mouseenter, etc.) per project convention
- All HTML attribute names and code references kept in English across all locales

## Test plan

- [x] JSON validation passes for all 8 modified files
- [x] Key structure verified: all 96 pagination keys match EN exactly in PT, ES, FR, IT
- [x] `shell.sidebar.pagination` present in all 5 locales (EN + 4 translations)
- [ ] Visual check: run `npm start`, switch locale to PT/ES/FR/IT, navigate to Pagination docs page