### PR TITLE
chore: update CHANGELOG and .ideas for pagination feature

### DIFF
--- a/.ideas/infinite-scroll-get-extension.md
+++ b/.ideas/infinite-scroll-get-extension.md
@@ -1,0 +1,79 @@
+# Infinite Scroll via `get` Directive Extension
+
+**Date:** 2026-06-05
+**Scope:** NoJS Core
+**Status:** Implemented (NOJS-98, 2026-06-05)
+
+## Concept
+
+Rather than building a separate "infinite scroll" element in NoJS-Elements, extend the existing Core `get` directive with scroll-triggered pagination. The `get` directive already fetches data declaratively (e.g., `get="/api/items"`), so pagination is a natural evolution of that capability. This keeps data-fetching concerns consolidated in Core and avoids an artificial split between "fetch once" and "fetch paginated."
+
+## API Design
+
+### Basic infinite scroll
+
+```html
+<div get="/api/items?page={page}"
+     get-trigger="scroll"
+     get-append
+     get-page="1">
+</div>
+```
+
+- `get-trigger="scroll"` — uses an Intersection Observer to trigger the next page load when the user scrolls near the bottom of the container.
+- `get-append` — appends fetched HTML to the existing content instead of replacing it.
+- `get-page` — tracks the current page number (starts at the specified value, auto-increments on each fetch).
+
+### Manual "Load More" variant
+
+```html
+<div get="/api/items?page={page}"
+     get-trigger="button"
+     get-append
+     get-page="1">
+</div>
+```
+
+- `get-trigger="button"` — renders a "Load More" button instead of auto-triggering on scroll. The user clicks to load the next page.
+
+### Declarative loading / empty / error states
+
+```html
+<div get="/api/items?page={page}"
+     get-trigger="scroll"
+     get-append
+     get-page="1">
+
+  <template get-loading>
+    <p>Loading more items...</p>
+  </template>
+
+  <template get-empty>
+    <p>No more items to load.</p>
+  </template>
+
+  <template get-error>
+    <p>Failed to load items. <button get-retry>Retry</button></p>
+  </template>
+</div>
+```
+
+### End-of-data signal
+
+The server signals "no more pages" by returning an empty response body or a response header (e.g., `X-NoJS-Last-Page: true`). When detected, the observer disconnects and the empty-state template renders.
+
+## Technical Notes
+
+- **Intersection Observer:** Attach a sentinel element at the bottom of the container. When it enters the viewport (with a configurable `rootMargin` threshold), increment `get-page` and re-evaluate the `get` URL template.
+- **URL templating:** The `{page}` token in the `get` URL is replaced with the current `get-page` value. This could generalize to other tokens like `{offset}` or `{cursor}` in the future.
+- **Append mode:** `get-append` inserts the response HTML before the sentinel element, preserving scroll position. Without `get-append`, the default `get` behavior (full replacement) still applies.
+- **Debouncing:** Scroll-triggered fetches should be debounced to prevent duplicate requests while a fetch is in flight.
+- **This belongs in Core** because `get` is already a Core directive. Adding pagination attributes alongside it keeps the API cohesive and avoids requiring Elements as a dependency for basic data-loading patterns.
+
+## Open Questions
+
+1. **Cursor-based pagination:** Should the API also support cursor-based pagination (e.g., `get-cursor` populated from a response header or JSON field)? This is common in modern APIs and offset/page-based pagination can miss or duplicate items.
+2. **Scroll container:** Should `get-trigger="scroll"` observe the window scroll or the nearest scrollable ancestor? Probably the nearest scrollable ancestor, with a fallback to the viewport.
+3. **Threshold configuration:** Should there be a `get-threshold` attribute to control how early the next page loads (e.g., `get-threshold="200px"` to start loading 200px before the sentinel is visible)?
+4. **Concurrency with existing `get` behavior:** How does this interact with `get-poll` (if that exists or is planned)? Need to ensure no conflicts between polling and scroll-triggered fetches.
+5. **SSR / progressive enhancement:** If JavaScript is disabled or hasn't loaded yet, the first page of content should still be server-rendered. The `get` extension should enhance, not replace, the initial content.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Pagination & Triggers** — extend the `get` directive with declarative pagination and fetch trigger control ([NOJS-98](https://github.com/ErickXavier/no-js/issues/98)):
+  - `get-insert` attribute: `append` or `prepend` insertion modes with sentinel-based positioning ([83580f4](https://github.com/ErickXavier/no-js/commit/83580f4))
+  - `get-trigger` attribute: `visible` (IntersectionObserver), `hover` (mouseenter), `none` (manual), `scroll` (infinite scroll), `button` (load more) ([a229263](https://github.com/ErickXavier/no-js/commit/a229263), [e44ee5c](https://github.com/ErickXavier/no-js/commit/e44ee5c))
+  - `get-page` attribute: offset-based pagination with auto-increment ([e44ee5c](https://github.com/ErickXavier/no-js/commit/e44ee5c))
+  - `get-cursor` and `get-cursor-field` attributes: cursor-based pagination with auto-detection from response headers or JSON body ([540e5af](https://github.com/ErickXavier/no-js/commit/540e5af))
+  - `get-threshold` attribute: configurable IntersectionObserver rootMargin ([a229263](https://github.com/ErickXavier/no-js/commit/a229263))
+  - `get-trigger-label` attribute: custom text for auto-generated load-more button ([e44ee5c](https://github.com/ErickXavier/no-js/commit/e44ee5c))
+  - End-of-data detection via empty response, `X-NoJS-Last-Page` header, or null cursor
+  - Scroll position preservation for prepend mode
+  - Mutual exclusivity guards: cursor vs page, scroll/button vs refresh
+- Pagination & Triggers documentation page with 7 live interactive demos
+- i18n translations (PT, ES, FR, IT) for pagination documentation
+- E2E tests: 17 Playwright tests covering pagination, triggers, and insert modes
+
+### Changed
+
+- `fetch.js`: expose response headers via `meta` parameter in `_doFetch` for cursor extraction
+
 ## [1.13.3] - 2026-06-05
 
 ### Fixed


### PR DESCRIPTION
## Summary

- Add `## [Unreleased]` section to CHANGELOG.md documenting all pagination and trigger attributes added in NOJS-98 (get-insert, get-trigger, get-page, get-cursor, get-cursor-field, get-threshold, get-trigger-label), documentation pages, i18n translations, and 17 E2E tests
- Update `.ideas/infinite-scroll-get-extension.md` status from "Idea" to "Implemented (NOJS-98, 2026-06-05)"

## Test plan

- [x] CHANGELOG follows Keep a Changelog format
- [x] .ideas status reflects implementation completion
- [x] No source code changes — documentation only