### PR TITLE
docs: update markdown docs for loop refactor + sibling else

### DIFF
--- a/docs/md/cheatsheet.md
+++ b/docs/md/cheatsheet.md
@@ -57,12 +57,16 @@ Complete reference of every No.JS directive.
 
 ## Loops
 
+The element with the loop directive IS the repeating template. It is removed from the DOM and clones are inserted as siblings.
+
 | Directive | Example | Description |
 |-----------|---------|-------------|
-| `foreach` | `foreach="item in items"` | Iterate over arrays (primary directive) |
+| `foreach` | `foreach="item in items"` | Iterate over arrays (primary directive). The element repeats as siblings. |
 | `each` | `each="item in items"` | Alias for `foreach` |
 | `for` | `for="item in items"` | Alias for `foreach` |
-| `template` | `template="tplId"` | Template to clone (optional — inline children used when omitted) |
+| `else` (sibling) | `<li else>No items</li>` | Sibling element shown when the loop array is empty/null/undefined |
+| `else` (template) | `else="emptyTpl"` | Reference an external template for the empty state |
+| `template` | `template="tplId"` | Template to clone for each item (optional — own children used when omitted) |
 | `index` | `index="i"` | Index variable name |
 | `key` | `key="item.id"` | Unique key for diffing |
 | `filter` | `filter="item.active"` | Filter expression |

--- a/docs/md/conditionals.md
+++ b/docs/md/conditionals.md
@@ -95,11 +95,24 @@ Render one of many templates based on a value.
 
 ---
 
+## `else` After Loop Siblings
+
+The `else` directive also works as a **sibling element after a loop**. When the loop array is empty, `null`, or `undefined`, the `else` sibling is shown:
+
+```html
+<ul>
+  <li each="item in items" bind="item.name"></li>
+  <li else>No items found</li>
+</ul>
+```
+
+This complements the conditional `if`/`else` pattern — `else` now works in both contexts. See [Loops](loops.md) for full details.
+
 ---
 
 ## See Also
 
-- [Loops](loops.md) — `foreach` with `filter` for conditional rendering of list items
+- [Loops](loops.md) — `foreach` with `filter` for conditional rendering, and sibling `else` for empty lists
 - [Dynamic Styling](styling.md) — `show`/`hide` alternative via `class-*`
 - [Templates](templates.md) — template-based conditional content with `then`/`else`
 

--- a/docs/md/data-fetching.md
+++ b/docs/md/data-fetching.md
@@ -89,11 +89,11 @@ Absolute URLs skip base resolution:
      as="users"
      loading="#usersSkeleton"
      error="#usersError"
-     empty="#noUsers"
      refresh="30000"
      cached>
 
   <div each="user in users" template="userCard"></div>
+  <p else>No users found.</p>
 
 </div>
 
@@ -103,10 +103,6 @@ Absolute URLs skip base resolution:
 
 <template id="usersError" var="err">
   <div class="error">Failed to load: <span bind="err.message"></span></div>
-</template>
-
-<template id="noUsers">
-  <p>No users found.</p>
 </template>
 ```
 
@@ -260,9 +256,9 @@ The skeleton is hidden automatically when:
 
 <div get="/api/feed" as="items"
      skeleton="skeleton"
-     loading="#spinnerTpl"
-     empty="#emptyTpl">
+     loading="#spinnerTpl">
   <div each="item in items" template="feedItem"></div>
+  <div else>No feed items</div>
 </div>
 ```
 

--- a/docs/md/error-handling.md
+++ b/docs/md/error-handling.md
@@ -11,6 +11,7 @@ Any HTTP directive (`get`, `post`, `put`, `patch`, `delete`) can declare an erro
 ```html
 <div get="/api/users" as="users" error="#usersError">
   <div each="user in users" template="userCard"></div>
+  <p else>No users found.</p>
 </div>
 
 <template id="usersError" var="err">

--- a/docs/md/examples.md
+++ b/docs/md/examples.md
@@ -84,10 +84,11 @@ automatically — no extra code needed in the route itself.
   <!-- Token is attached automatically via the request interceptor -->
   <div get="/me/dashboard" as="data" loading="#dash-skeleton">
     <h2 bind="'Welcome, ' + data.user.name"></h2>
-    <div each="m in data.metrics">
+    <p each="m in data.metrics">
       <span bind="m.label"></span>
       <span bind="m.value | number"></span>
-    </div>
+    </p>
+    <p else>No metrics available</p>
   </div>
   <button on:click="$store.auth.user = null; $store.auth.token = null">
     Sign out
@@ -123,10 +124,10 @@ manipulation.
       No results for <strong bind="query"></strong>
     </p>
 
-    <div each="item in results">
+    <p each="item in results">
       <span bind="item.name"></span>
       <span bind="item.price | currency"></span>
-    </div>
+    </p>
 
   </div>
 </div>
@@ -157,15 +158,16 @@ simultaneously — no event bus, no shared component.
       Add to cart
     </button>
   </div>
+  <div else>No products available</div>
 </div>
 
 <!-- Cart summary: somewhere else entirely -->
-<div show="$store.cart.items.length > 0">
-  <div each="item in $store.cart.items">
+<ul show="$store.cart.items.length > 0">
+  <li each="item in $store.cart.items">
     <span bind="item.name"></span>
     <span bind="item.price | currency"></span>
-  </div>
-</div>
+  </li>
+</ul>
 ```
 
 **Key concepts:** `store` · `$store.*` cross-component reactivity · `each` · `show`
@@ -188,10 +190,10 @@ A server-status dashboard that refreshes automatically every 5 seconds using the
         bind="s.healthy ? 'Online' : 'Degraded'">
   </span>
 
-  <div each="metric in s.metrics">
+  <p each="metric in s.metrics">
     <span bind="metric.label"></span>
     <span bind="metric.value | number"></span>
-  </div>
+  </p>
 
 </div>
 ```
@@ -264,10 +266,11 @@ All five patterns combined into a single production-grade SPA:
   <template route="/dashboard" guard="$store.auth.token" redirect="/login">
     <div get="/me/dashboard" as="data">
       <h1 bind="'Welcome, ' + data.user.name"></h1>
-      <div each="m in data.metrics">
+      <p each="m in data.metrics">
         <span bind="m.label"></span>
         <span bind="m.value | number"></span>
-      </div>
+      </p>
+      <p else>No metrics available</p>
     </div>
     <button on:click="$store.auth.user = null; $store.auth.token = null">
       Sign out

--- a/docs/md/loops.md
+++ b/docs/md/loops.md
@@ -2,11 +2,11 @@
 
 ## `foreach` — Iterate Over Arrays
 
-`foreach` is the primary iteration directive. It repeats its content for each item in an array.
+`foreach` is the primary iteration directive. The element that carries the directive IS the repeating template — it is removed from the DOM, and clones are inserted as siblings between comment markers for each item in the array.
 
-### Inline Children (default)
+### Self-Repeating Element
 
-When no `template` attribute is provided, the element's children are used as the repeating template:
+The element with `foreach` (or `each` / `for`) is the template itself. No wrapper element is needed — the loop element repeats as a sibling:
 
 ```html
 <div get="/posts" as="posts">
@@ -20,13 +20,17 @@ When no `template` attribute is provided, the element's children are used as the
 </div>
 ```
 
+Each `<li>` clone is inserted directly inside the `<ul>`. The original `<li foreach="...">` element is removed and used as the template source.
+
 ### External Template
 
-Use the `template` attribute to reference a `<template>` element by ID:
+Use the `template` attribute to reference a `<template>` element by ID. The loop element is still the repeating unit — clones of the referenced template are inserted as siblings:
 
 ```html
 <div get="/posts" as="posts">
-  <div foreach="post in posts" key="post.id" template="postCard"></div>
+  <ul>
+    <li foreach="post in posts" key="post.id" template="postCard"></li>
+  </ul>
 </div>
 
 <template id="postCard">
@@ -45,7 +49,6 @@ Use the `template` attribute to reference a `<template>` element by ID:
   <li foreach="item in menuItems"
       index="idx"
       key="item.id"
-      else="#noItems"
       filter="item.active"
       sort="item.order"
       limit="10"
@@ -54,10 +57,36 @@ Use the `template` attribute to reference a `<template>` element by ID:
       <span bind="idx + 1"></span> - <span bind="item.label"></span>
     </a>
   </li>
+  <li else>No items available</li>
+</ul>
+```
+
+### Sibling `else` for Empty Lists
+
+When the source array is empty, `null`, or `undefined`, the loop renders nothing. Place a sibling element with `else` immediately after the loop element to show fallback content:
+
+```html
+<ul>
+  <li foreach="item in items" bind="item.name"></li>
+  <li else>No items found</li>
+</ul>
+```
+
+The `else` element is hidden when items exist and shown when the list is empty. This works with all three aliases (`foreach`, `each`, `for`).
+
+You can also reference an external template with `else="templateId"`:
+
+```html
+<ul>
+  <li foreach="item in items" bind="item.name"></li>
+  <li else="emptyTpl"></li>
 </ul>
 
-<template id="noItems">
-  <li class="empty">No items available</li>
+<template id="emptyTpl">
+  <li class="empty-state">
+    <p>Nothing to display.</p>
+    <button on:click="reload()">Retry</button>
+  </li>
 </template>
 ```
 
@@ -66,10 +95,9 @@ Use the `template` attribute to reference a `<template>` element by ID:
 | Attribute | Description |
 |-----------|-------------|
 | `foreach` | `"item in array"` — variable name and source expression |
-| `template` | ID of the `<template>` element to clone for each item (optional — when omitted, inline children are the template) |
+| `template` | ID of the `<template>` element to clone for each item (optional — when omitted, the element's own children are the template) |
 | `index` | Variable name for the index (default: `$index`) |
 | `key` | Unique key expression for DOM diffing |
-| `else` | Template ID to render when array is empty |
 | `filter` | Expression to filter items (like `Array.filter`) |
 | `sort` | Property path to sort by (prefix with `-` for descending) |
 | `limit` | Maximum number of items to render |
@@ -79,17 +107,19 @@ Use the `template` attribute to reference a `<template>` element by ID:
 | `animate-stagger` | Delay (ms) between each item's enter animation |
 | `animate-duration` | Max duration (ms) before leave animation is force-completed |
 
+The sibling `else` element is documented above — it is placed after the loop element, not as an attribute on it.
+
 ---
 
 ## Aliases: `each` and `for`
 
-`each` and `for` are aliases for `foreach`. They share the same handler and support all the same attributes — `filter`, `sort`, `limit`, `offset`, `key`, `animate-*`, `else`, `template`, `index`, and loop variables.
+`each` and `for` are aliases for `foreach`. They share the same handler and support all the same attributes — `filter`, `sort`, `limit`, `offset`, `key`, `animate-*`, `template`, `index`, and loop variables. The sibling `else` element also works with all three.
 
 ```html
-<!-- All three are equivalent -->
-<div foreach="item in items" key="item.id">...</div>
-<div each="item in items" key="item.id">...</div>
-<div for="item in items" key="item.id">...</div>
+<!-- All three are equivalent — the element repeats as siblings -->
+<li foreach="item in items" key="item.id">...</li>
+<li each="item in items" key="item.id">...</li>
+<li for="item in items" key="item.id">...</li>
 ```
 
 Use whichever reads best for your context. `foreach` is the canonical name used throughout this documentation.
@@ -120,10 +150,10 @@ When you supply a `key` attribute, the directive switches to **key-based reconci
 
 ```html
 <!-- Without key: full rebuild on every change -->
-<div foreach="item in items" template="itemTpl"></div>
+<li foreach="item in items" template="itemTpl"></li>
 
 <!-- With key: only changed items are added/removed -->
-<div foreach="item in items" key="item.id" template="itemTpl"></div>
+<li foreach="item in items" key="item.id" template="itemTpl"></li>
 ```
 
 The `key` value must be **unique and stable** across renders — typically a database ID or UUID. Using a non-unique key (e.g. `$index`) defeats reconciliation since items will always appear to match.
@@ -140,7 +170,7 @@ The `key` value must be **unique and stable** across renders — typically a dat
 
 ### Positional metadata after reorder
 
-After a reorder (e.g. sort), the reconciler calls `$notify()` on the context of each retained wrapper. This propagates the updated `$index`, `$first`, `$last`, `$even`, `$odd`, and `$count` values to all child watchers, including nested bindings and class expressions that depend on position.
+After a reorder (e.g. sort), the reconciler calls `$notify()` on the context of each retained clone. This propagates the updated `$index`, `$first`, `$last`, `$even`, `$odd`, and `$count` values to all child watchers, including nested bindings and class expressions that depend on position.
 
 ```html
 <template id="itemTpl">
@@ -167,24 +197,38 @@ Inside any loop, these variables are automatically available:
 | `$odd` | `true` if index is odd |
 
 ```html
-<div foreach="item in items">
-  <div class-first="$first"
-       class-last="$last"
-       class-striped="$odd">
-    <span bind="($index + 1) + ' of ' + $count"></span>
-    <span bind="item.name"></span>
-  </div>
-</div>
+<ul>
+  <li foreach="item in items">
+    <span class-first="$first"
+         class-last="$last"
+         class-striped="$odd">
+      <span bind="($index + 1) + ' of ' + $count"></span>
+      <span bind="item.name"></span>
+    </span>
+  </li>
+</ul>
 ```
 
 ---
 
 ## Nested Loops
 
-Child loops can access parent scope variables:
+Child loops can access parent scope variables. Each loop element repeats as siblings inside its container:
 
 ```html
-<div foreach="category in categories" template="catTpl"></div>
+<div foreach="category in categories">
+  <h3 bind="category.name"></h3>
+  <p foreach="product in category.products">
+    <!-- Access both product AND category from parent scope -->
+    <span bind="category.name"></span>: <span bind="product.name"></span>
+  </p>
+</div>
+```
+
+With external templates:
+
+```html
+<section foreach="category in categories" template="catTpl"></section>
 
 <template id="catTpl">
   <h3 bind="category.name"></h3>
@@ -192,7 +236,6 @@ Child loops can access parent scope variables:
 </template>
 
 <template id="prodTpl">
-  <!-- Access both product AND category from parent scope -->
   <p><span bind="category.name"></span>: <span bind="product.name"></span></p>
 </template>
 ```
@@ -207,9 +250,9 @@ Loop directives are fully reactive. When the source array changes (push, splice,
 
 ```html
 <div state="{ items: ['A', 'B', 'C'] }">
-  <div foreach="item in items">
-    <span bind="item"></span>
-  </div>
+  <ul>
+    <li foreach="item in items" bind="item"></li>
+  </ul>
   <button on:click="items.push('New')">Add Item</button>
   <!-- Loop updates automatically -->
 </div>
@@ -217,15 +260,16 @@ Loop directives are fully reactive. When the source array changes (push, splice,
 
 > **Note:** `foreach`/`each`/`for` iterate over arrays only. Object iteration is not directly supported — use the `keys` or `values` filter to convert objects to arrays first:
 > ```html
-> <div foreach="key in settings | keys">
+> <span foreach="key in settings | keys">
 >   <span bind="key"></span>: <span bind="settings[key]"></span>
-> </div>
+> </span>
 > ```
 
 ---
 
 ## See Also
 
+- [Conditionals](conditionals.md) — `else` also works as a sibling after loop elements
 - [Templates](templates.md) — external templates referenced by loops
 - [Animations](animations.md) — `animate-stagger` for list enter/leave effects
 - [Filters & Pipes](filters.md) — `count`, `first`, `last`, `reverse`, `sortBy` filters

--- a/docs/md/templates.md
+++ b/docs/md/templates.md
@@ -158,9 +158,31 @@ Both plain IDs and `#id` syntax are accepted. Each `include` creates a fresh ind
 
 ---
 
+## Templates with Loops
+
+Loop directives use the `template` attribute to reference external templates. The loop element is the repeating unit — clones of the referenced template are inserted as siblings:
+
+```html
+<ul get="/api/users" as="users">
+  <li each="user in users" template="userCard"></li>
+  <li else>No users found</li>
+</ul>
+
+<template id="userCard">
+  <div class="card">
+    <h3 bind="user.name"></h3>
+    <p bind="user.email"></p>
+  </div>
+</template>
+```
+
+The sibling `else` element shows when the array is empty. You can also point `else` at a template ID: `else="emptyTpl"`.
+
+---
+
 ## See Also
 
-- [Loops](loops.md) — `template` attribute for loop item templates
+- [Loops](loops.md) — self-repeating elements and sibling `else` for empty lists
 - [Routing](routing.md) — route templates and file-based routing
 - [Data Fetching](data-fetching.md) — `loading`, `error`, `success` templates
 


### PR DESCRIPTION
## Summary

- Converts all loop examples across 7 markdown doc files to the self-repeating element pattern (the element with `foreach`/`each`/`for` IS the template that repeats as siblings)
- Adds documentation for the new sibling `else` element that shows fallback content when the loop array is empty/null/undefined
- Updates `loops.md` with new Self-Repeating Element section, Sibling `else` for Empty Lists section, and revised attribute table
- Adds cross-references between conditionals, loops, and templates docs for the new `else` behavior

## Files changed

- `docs/md/loops.md` -- Primary loop docs: complete rewrite with new pattern + sibling else section
- `docs/md/examples.md` -- Updated all loop code examples in real-world patterns
- `docs/md/cheatsheet.md` -- Added sibling else rows, updated loop descriptions
- `docs/md/data-fetching.md` -- Updated get/as + loop examples, replaced empty= with sibling else
- `docs/md/conditionals.md` -- Added section on else after loop siblings
- `docs/md/templates.md` -- Added templates-with-loops section showing new pattern
- `docs/md/error-handling.md` -- Added sibling else to error handling example

## Test plan

- [ ] Review all code examples for correct HTML structure (loop directive on repeating element, not container)
- [ ] Verify sibling else examples are consistent across all files
- [ ] Cross-check attribute table in loops.md matches implementation
- [ ] Verify no stale references to old container-based loop pattern remain