### PR TITLE
docs(loops): update HTML docs and i18n for self-repeating loop pattern

### DIFF
--- a/docs/locales/en/docs.json
+++ b/docs/locales/en/docs.json
@@ -136,7 +136,8 @@
         "filter": "Filter expression",
         "sort": "Sort property (name only, not prefixed with item variable)",
         "limit": "Max items",
-        "offset": "Skip items"
+        "offset": "Skip items",
+        "else": "Sibling element shown when array is empty"
       },
       "events": {
         "title": "Events",
@@ -485,7 +486,7 @@
       },
       "foreach": {
         "title": "foreach — Iterate Over Arrays",
-        "text": "The primary iteration directive. Use foreach=\"item in array\" to loop over arrays. each and for are aliases with identical behavior.",
+        "text": "The primary iteration directive. Place foreach=\"item in array\" on the repeating element itself (self-repeating pattern). The element and its children are cloned for each item. each and for are aliases with identical behavior.",
         "preview": "Preview",
         "col1": "Attribute",
         "col2": "Description",
@@ -493,7 +494,7 @@
         "from": "Source array (DEPRECATED — use item in array syntax)",
         "index": "Variable name for the index (default: $index)",
         "key": "Unique key expression for element identification and tracking",
-        "else": "Template ID to render when array is empty",
+        "else": "Sibling element with else attribute, shown when array is empty",
         "filter": "Expression to filter items",
         "sort": "Property path to sort by (prefix - for descending)",
         "limit": "Maximum number of items to render",
@@ -502,15 +503,15 @@
       },
       "fullExample": {
         "title": "Full Example with All Attributes",
-        "text": "A complete example showing foreach with filtering, sorting, pagination, and an empty-state fallback."
+        "text": "A complete example showing foreach with filtering, sorting, pagination, and a sibling else for the empty-state fallback."
       },
       "aliases": {
         "title": "Aliases: each and for",
         "text": "each and for are aliases of foreach — they share the same handler and support all the same attributes."
       },
       "inline": {
-        "title": "Inline Children Template",
-        "text": "When no template attribute is specified, the element's children become the repeating template."
+        "title": "Self-Repeating Pattern",
+        "text": "Place the loop directive on the repeating element itself. The element is cloned for each item in the array. Add a sibling element with else to handle empty arrays."
       },
       "deprecated": {
         "title": "Deprecated: from Attribute",

--- a/docs/locales/es/docs.json
+++ b/docs/locales/es/docs.json
@@ -136,7 +136,8 @@
         "filter": "Expresión de filtro",
         "sort": "Propiedad para ordenar (solo el nombre, sin prefijo de variable de elemento)",
         "limit": "Máximo de elementos",
-        "offset": "Omitir elementos"
+        "offset": "Omitir elementos",
+        "else": "Elemento hermano mostrado cuando el array está vacío"
       },
       "events": {
         "title": "Eventos",
@@ -485,14 +486,14 @@
       },
       "foreach": {
         "title": "foreach — Iterar Sobre Arrays",
-        "text": "La directiva de iteración primaria. Usa foreach=\"item in array\" para iterar sobre arrays. each y for son aliases con comportamiento idéntico.",
+        "text": "La directiva de iteración primaria. Coloca foreach=\"item in array\" en el elemento que se repite (self-repeating pattern). El elemento y sus hijos se clonan para cada item. each y for son aliases con comportamiento idéntico.",
         "col1": "Atributo",
         "col2": "Descripción",
         "foreach": "Expresión: item in array",
         "from": "Array de origen (DEPRECATED — usa la sintaxis item in array)",
         "index": "Nombre de variable para el índice (por defecto: $index)",
         "key": "Expresión de clave única para identificación y seguimiento de elementos",
-        "else": "ID de plantilla a renderizar cuando el array está vacío",
+        "else": "Elemento hermano con atributo else, mostrado cuando el array está vacío",
         "filter": "Expresión para filtrar elementos",
         "sort": "Ruta de propiedad para ordenar (prefijo - para descendente)",
         "limit": "Número máximo de elementos a renderizar",
@@ -502,15 +503,15 @@
       },
       "fullExample": {
         "title": "Ejemplo completo con todos los atributos",
-        "text": "Un ejemplo completo mostrando foreach con filtrado, ordenación, paginación y un fallback para estado vacío."
+        "text": "Un ejemplo completo mostrando foreach con filtrado, ordenación, paginación y un else hermano para el fallback de estado vacío."
       },
       "aliases": {
         "title": "Aliases: each y for",
         "text": "each y for son aliases de foreach — comparten el mismo handler y soportan todos los mismos atributos."
       },
       "inline": {
-        "title": "Plantilla Inline de Hijos",
-        "text": "Cuando no se especifica el atributo template, los hijos del elemento se convierten en la plantilla de repetición."
+        "title": "Self-Repeating Pattern",
+        "text": "Coloca la directiva de loop en el propio elemento que se repite. El elemento se clona para cada item del array. Agrega un elemento hermano con else para manejar arrays vacíos."
       },
       "deprecated": {
         "title": "Deprecated: Atributo from",

--- a/docs/locales/fr/docs.json
+++ b/docs/locales/fr/docs.json
@@ -136,7 +136,8 @@
         "filter": "Expression de filtrage",
         "sort": "Propriété de tri (nom seul, sans préfixe de variable d'élément)",
         "limit": "Nombre maximum d'éléments",
-        "offset": "Éléments à ignorer"
+        "offset": "Éléments à ignorer",
+        "else": "Élément frère affiché quand le tableau est vide"
       },
       "events": {
         "title": "Événements",
@@ -485,14 +486,14 @@
       },
       "foreach": {
         "title": "foreach — Itérer sur des tableaux",
-        "text": "La directive d'itération principale. Utilisez foreach=\"item in array\" pour itérer sur des tableaux. each et for sont des alias avec un comportement identique.",
+        "text": "La directive d'itération principale. Placez foreach=\"item in array\" sur l'élément qui se répète (self-repeating pattern). L'élément et ses enfants sont clonés pour chaque item. each et for sont des alias avec un comportement identique.",
         "col1": "Attribut",
         "col2": "Description",
         "foreach": "Expression : item in array",
         "from": "Tableau source (DEPRECATED — utilisez la syntaxe item in array)",
         "index": "Nom de la variable d'index (par défaut : $index)",
         "key": "Expression de clé unique pour l'identification et le suivi des éléments",
-        "else": "ID du template à afficher quand le tableau est vide",
+        "else": "Élément frère avec attribut else, affiché quand le tableau est vide",
         "filter": "Expression pour filtrer les éléments",
         "sort": "Chemin de propriété pour le tri (préfixe - pour l'ordre décroissant)",
         "limit": "Nombre maximum d'éléments à afficher",
@@ -502,15 +503,15 @@
       },
       "fullExample": {
         "title": "Exemple complet avec tous les attributs",
-        "text": "Un exemple complet montrant foreach avec filtrage, tri, pagination et un template de secours pour l'état vide."
+        "text": "Un exemple complet montrant foreach avec filtrage, tri, pagination et un else frère pour le secours d'état vide."
       },
       "aliases": {
         "title": "Alias : each et for",
         "text": "each et for sont des alias de foreach — ils partagent le même handler et supportent tous les mêmes attributs."
       },
       "inline": {
-        "title": "Template enfants inline",
-        "text": "Quand aucun attribut template n'est spécifié, les enfants de l'élément deviennent le template répété."
+        "title": "Self-Repeating Pattern",
+        "text": "Placez la directive de boucle sur l'élément qui se répète lui-même. L'élément est cloné pour chaque item du tableau. Ajoutez un élément frère avec else pour gérer les tableaux vides."
       },
       "deprecated": {
         "title": "Déprécié : attribut from",

--- a/docs/locales/it/docs.json
+++ b/docs/locales/it/docs.json
@@ -136,7 +136,8 @@
         "filter": "Espressione di filtro",
         "sort": "Proprietà di ordinamento (solo nome, senza prefisso della variabile elemento)",
         "limit": "Numero massimo di elementi",
-        "offset": "Salta elementi"
+        "offset": "Salta elementi",
+        "else": "Elemento fratello mostrato quando l'array è vuoto"
       },
       "events": {
         "title": "Eventi",
@@ -485,14 +486,14 @@
       },
       "foreach": {
         "title": "foreach — Itera sugli array",
-        "text": "La direttiva di iterazione principale. Usa foreach=\"item in array\" per iterare sugli array. each e for sono alias con comportamento identico.",
+        "text": "La direttiva di iterazione principale. Posiziona foreach=\"item in array\" sull'elemento che si ripete (self-repeating pattern). L'elemento e i suoi figli vengono clonati per ogni item. each e for sono alias con comportamento identico.",
         "col1": "Attributo",
         "col2": "Descrizione",
         "foreach": "Espressione: item in array",
         "from": "Array sorgente (DEPRECATED — usa la sintassi item in array)",
         "index": "Nome della variabile per l'indice (default: $index)",
         "key": "Espressione chiave univoca per l'identificazione e il tracciamento degli elementi",
-        "else": "ID del template da renderizzare quando l'array è vuoto",
+        "else": "Elemento fratello con attributo else, mostrato quando l'array è vuoto",
         "filter": "Espressione per filtrare gli elementi",
         "sort": "Percorso della proprietà per l'ordinamento (prefisso - per ordine decrescente)",
         "limit": "Numero massimo di elementi da renderizzare",
@@ -502,15 +503,15 @@
       },
       "fullExample": {
         "title": "Esempio completo con tutti gli attributi",
-        "text": "Un esempio completo che mostra foreach con filtraggio, ordinamento, paginazione e un template di fallback per lo stato vuoto."
+        "text": "Un esempio completo che mostra foreach con filtraggio, ordinamento, paginazione e un else fratello per il fallback di stato vuoto."
       },
       "aliases": {
         "title": "Alias: each e for",
         "text": "each e for sono alias di foreach — condividono lo stesso handler e supportano tutti gli stessi attributi."
       },
       "inline": {
-        "title": "Template figli inline",
-        "text": "Quando nessun attributo template è specificato, i figli dell'elemento diventano il template ripetuto."
+        "title": "Self-Repeating Pattern",
+        "text": "Posiziona la direttiva di loop sull'elemento che si ripete. L'elemento viene clonato per ogni item dell'array. Aggiungi un elemento fratello con else per gestire array vuoti."
       },
       "deprecated": {
         "title": "Deprecato: attributo from",

--- a/docs/locales/pt/docs.json
+++ b/docs/locales/pt/docs.json
@@ -136,7 +136,8 @@
         "filter": "Expressão de filtro",
         "sort": "Propriedade para ordenação (apenas nome, sem prefixo da variável do item)",
         "limit": "Máximo de itens",
-        "offset": "Pular itens"
+        "offset": "Pular itens",
+        "else": "Elemento irmão exibido quando o array está vazio"
       },
       "events": {
         "title": "Eventos",
@@ -485,14 +486,14 @@
       },
       "foreach": {
         "title": "foreach — Iterar Sobre Arrays",
-        "text": "A diretiva de iteração primária. Use foreach=\"item in array\" para iterar sobre arrays. each e for são aliases com comportamento idêntico.",
+        "text": "A diretiva de iteração primária. Coloque foreach=\"item in array\" no elemento que se repete (self-repeating pattern). O elemento e seus filhos são clonados para cada item. each e for são aliases com comportamento idêntico.",
         "col1": "Atributo",
         "col2": "Descrição",
         "foreach": "Expressão: item in array",
         "from": "Array de origem (DEPRECATED — use a sintaxe item in array)",
         "index": "Nome da variável para o índice (padrão: $index)",
         "key": "Expressão de chave única para identificação e rastreamento de elementos",
-        "else": "ID do template para renderizar quando o array está vazio",
+        "else": "Elemento irmão com atributo else, exibido quando o array está vazio",
         "filter": "Expressão para filtrar itens",
         "sort": "Caminho da propriedade para ordenar (prefixo - para descendente)",
         "limit": "Número máximo de itens para renderizar",
@@ -502,15 +503,15 @@
       },
       "fullExample": {
         "title": "Exemplo completo com todos os atributos",
-        "text": "Um exemplo completo mostrando foreach com filtragem, ordenação, paginação e um fallback para estado vazio."
+        "text": "Um exemplo completo mostrando foreach com filtragem, ordenação, paginação e um else irmão para o fallback de estado vazio."
       },
       "aliases": {
         "title": "Aliases: each e for",
         "text": "each e for são aliases de foreach — compartilham o mesmo handler e suportam todos os mesmos atributos."
       },
       "inline": {
-        "title": "Template Inline de Filhos",
-        "text": "Quando nenhum atributo template é especificado, os filhos do elemento se tornam o template de repetição."
+        "title": "Self-Repeating Pattern",
+        "text": "Coloque a diretiva de loop no próprio elemento que se repete. O elemento é clonado para cada item do array. Adicione um elemento irmão com else para tratar arrays vazios."
       },
       "deprecated": {
         "title": "Deprecated: Atributo from",

--- a/docs/playground/examples/chat.html
+++ b/docs/playground/examples/chat.html
@@ -1,4 +1,4 @@
-<!-- Templates: reusable HTML fragments used by "each" loops -->
+<!-- Templates: reusable HTML fragments used by loops -->
 
 <!-- Contact template: renders a single contact row in the sidebar -->
 <template id="contact-tpl">

--- a/docs/playground/examples/kanban.html
+++ b/docs/playground/examples/kanban.html
@@ -1,4 +1,4 @@
-<!-- Templates: reusable HTML fragments used by drag-list and "each" loops -->
+<!-- Templates: reusable HTML fragments used by drag-list and loops -->
 
 <!-- Tag template: renders a single tag label with conditional colors -->
 <template id="tag-tpl">

--- a/docs/templates/docs/animations.tpl
+++ b/docs/templates/docs/animations.tpl
@@ -73,10 +73,10 @@
     <h2 class="doc-title" id="animations-loop" t="docs.animations.loopAnimations.title"></h2>
     <p class="doc-text" t="docs.animations.loopAnimations.text"></p>
     <div class="code-block"><pre><span class="hl-tag">&lt;div</span> <span class="hl-attr">each</span>=<span class="hl-str">"item in items"</span>
-     <span class="hl-attr">template</span>=<span class="hl-str">"itemTpl"</span>
      <span class="hl-attr">animate-enter</span>=<span class="hl-str">"fadeInUp"</span>
      <span class="hl-attr">animate-leave</span>=<span class="hl-str">"fadeOutDown"</span>
      <span class="hl-attr">animate-stagger</span>=<span class="hl-str">"50"</span><span class="hl-tag">&gt;</span>  <span class="hl-cmt">&lt;!-- 50ms delay between each item --&gt;</span>
+  <span class="hl-tag">&lt;span</span> <span class="hl-attr">bind</span>=<span class="hl-str">"item.name"</span><span class="hl-tag">&gt;&lt;/span&gt;</span>
 <span class="hl-tag">&lt;/div&gt;</span></pre></div>
   </div>
 

--- a/docs/templates/docs/cheatsheet.tpl
+++ b/docs/templates/docs/cheatsheet.tpl
@@ -97,6 +97,7 @@
         <tr><td><code>sort</code></td><td><code>sort="name"</code></td><td t="docs.cheatsheet.loops.sort"></td></tr>
         <tr><td><code>limit</code></td><td><code>limit="10"</code></td><td t="docs.cheatsheet.loops.limit"></td></tr>
         <tr><td><code>offset</code></td><td><code>offset="5"</code></td><td t="docs.cheatsheet.loops.offset"></td></tr>
+        <tr><td><code>else</code> <small>(sibling)</small></td><td><code>&lt;li else&gt;No items&lt;/li&gt;</code></td><td t="docs.cheatsheet.loops.else"></td></tr>
       </tbody>
     </table>
   </div>

--- a/docs/templates/docs/getting-started.tpl
+++ b/docs/templates/docs/getting-started.tpl
@@ -87,7 +87,7 @@ NoJS.init();</pre></div>
     <div class="code-block"><pre><span class="hl-cmt">body          → context: { baseUrl }</span>
 <span class="hl-cmt">  div[get]    → context: { user: { name, email } }  ← inherits from body</span>
 <span class="hl-cmt">    span[bind="user.name"]                           ← reads from div's context</span>
-<span class="hl-cmt">    div[each] → context: { post: { title } }         ← inherits from div</span></pre></div>
+<span class="hl-cmt">    p[each]   → context: { post: { title } }         ← self-repeating, inherits from div</span></pre></div>
 
     <h3 class="doc-subtitle" id="getting-started-directive-priority" t="docs.gettingStarted.coreConcepts.directivePrioritySubtitle"></h3>
     <table class="doc-table">

--- a/docs/templates/docs/loops.tpl
+++ b/docs/templates/docs/loops.tpl
@@ -14,25 +14,18 @@
     <p class="doc-text" t="docs.loops.foreach.text"></p>
     <div class="demo-split">
       <div class="demo-code"><pre><span class="hl-tag">&lt;div</span> <span class="hl-attr">get</span>=<span class="hl-str">"/posts"</span> <span class="hl-attr">as</span>=<span class="hl-str">"posts"</span><span class="hl-tag">&gt;</span>
-  <span class="hl-tag">&lt;div</span> <span class="hl-attr">foreach</span>=<span class="hl-str">"post in posts"</span>
-       <span class="hl-attr">template</span>=<span class="hl-str">"postCard"</span><span class="hl-tag">&gt;&lt;/div&gt;</span>
-<span class="hl-tag">&lt;/div&gt;</span>
-
-<span class="hl-tag">&lt;template</span> <span class="hl-attr">id</span>=<span class="hl-str">"postCard"</span><span class="hl-tag">&gt;</span>
-  <span class="hl-tag">&lt;article&gt;</span>
+  <span class="hl-tag">&lt;article</span> <span class="hl-attr">foreach</span>=<span class="hl-str">"post in posts"</span><span class="hl-tag">&gt;</span>
     <span class="hl-tag">&lt;h2</span> <span class="hl-attr">bind</span>=<span class="hl-str">"post.title"</span><span class="hl-tag">&gt;&lt;/h2&gt;</span>
     <span class="hl-tag">&lt;span</span> <span class="hl-attr">bind</span>=<span class="hl-str">"'#' + $index"</span><span class="hl-tag">&gt;&lt;/span&gt;</span>
   <span class="hl-tag">&lt;/article&gt;</span>
-<span class="hl-tag">&lt;/template&gt;</span></pre></div>
+  <span class="hl-tag">&lt;p</span> <span class="hl-attr">else</span><span class="hl-tag">&gt;</span>No posts found<span class="hl-tag">&lt;/p&gt;</span>
+<span class="hl-tag">&lt;/div&gt;</span></pre></div>
       <div class="demo-preview" state="{ fruits: ['Apple', 'Banana', 'Cherry', 'Date'] }">
         <div class="demo-result-label" t="docs.loops.foreach.preview"></div>
-        <div foreach="fruit in fruits" template="fruitItem"></div>
-        <template id="fruitItem">
-          <div class="item-row">
-            <span class="item-index" bind="$index + 1"></span>
-            <span class="item-name" bind="fruit"></span>
-          </div>
-        </template>
+        <div class="item-row" foreach="fruit in fruits">
+          <span class="item-index" bind="$index + 1"></span>
+          <span class="item-name" bind="fruit"></span>
+        </div>
       </div>
     </div>
   </div>
@@ -41,23 +34,19 @@
   <div class="doc-section">
     <h2 class="doc-title" id="loops-full-example" t="docs.loops.fullExample.title"></h2>
     <p class="doc-text" t="docs.loops.fullExample.text"></p>
-    <div class="code-block"><pre><span class="hl-tag">&lt;ul</span> <span class="hl-attr">foreach</span>=<span class="hl-str">"item in menuItems"</span>
-    <span class="hl-attr">index</span>=<span class="hl-str">"idx"</span>
-    <span class="hl-attr">key</span>=<span class="hl-str">"item.id"</span>
-    <span class="hl-attr">else</span>=<span class="hl-str">"#noItems"</span>
-    <span class="hl-attr">filter</span>=<span class="hl-str">"item.active"</span>
-    <span class="hl-attr">sort</span>=<span class="hl-str">"order"</span>
-    <span class="hl-attr">limit</span>=<span class="hl-str">"10"</span><span class="hl-tag">&gt;</span>
-  <span class="hl-tag">&lt;li&gt;</span>
+    <div class="code-block"><pre><span class="hl-tag">&lt;ul&gt;</span>
+  <span class="hl-tag">&lt;li</span> <span class="hl-attr">foreach</span>=<span class="hl-str">"item in menuItems"</span>
+      <span class="hl-attr">index</span>=<span class="hl-str">"idx"</span>
+      <span class="hl-attr">key</span>=<span class="hl-str">"item.id"</span>
+      <span class="hl-attr">filter</span>=<span class="hl-str">"item.active"</span>
+      <span class="hl-attr">sort</span>=<span class="hl-str">"order"</span>
+      <span class="hl-attr">limit</span>=<span class="hl-str">"10"</span><span class="hl-tag">&gt;</span>
     <span class="hl-tag">&lt;a</span> <span class="hl-attr">bind-href</span>=<span class="hl-str">"item.link"</span><span class="hl-tag">&gt;</span>
       <span class="hl-tag">&lt;span</span> <span class="hl-attr">bind</span>=<span class="hl-str">"item.label"</span><span class="hl-tag">&gt;&lt;/span&gt;</span>
     <span class="hl-tag">&lt;/a&gt;</span>
   <span class="hl-tag">&lt;/li&gt;</span>
-<span class="hl-tag">&lt;/ul&gt;</span>
-
-<span class="hl-tag">&lt;template</span> <span class="hl-attr">id</span>=<span class="hl-str">"noItems"</span><span class="hl-tag">&gt;</span>
-  <span class="hl-tag">&lt;li</span> <span class="hl-attr">class</span>=<span class="hl-str">"empty"</span><span class="hl-tag">&gt;</span>No items available<span class="hl-tag">&lt;/li&gt;</span>
-<span class="hl-tag">&lt;/template&gt;</span></pre></div>
+  <span class="hl-tag">&lt;li</span> <span class="hl-attr">else</span> <span class="hl-attr">class</span>=<span class="hl-str">"empty"</span><span class="hl-tag">&gt;</span>No items available<span class="hl-tag">&lt;/li&gt;</span>
+<span class="hl-tag">&lt;/ul&gt;</span></pre></div>
 
     <table class="doc-table">
       <thead>
@@ -68,7 +57,7 @@
         <tr><td><code>template</code></td><td t="docs.loops.foreach.template"></td></tr>
         <tr><td><code>index</code></td><td t="docs.loops.foreach.index"></td></tr>
         <tr><td><code>key</code></td><td t="docs.loops.foreach.key"></td></tr>
-        <tr><td><code>else</code></td><td t="docs.loops.foreach.else"></td></tr>
+        <tr><td><code>else</code> <small>(sibling)</small></td><td t="docs.loops.foreach.else"></td></tr>
         <tr><td><code>filter</code></td><td t="docs.loops.foreach.filter"></td></tr>
         <tr><td><code>sort</code></td><td t="docs.loops.foreach.sort"></td></tr>
         <tr><td><code>limit</code></td><td t="docs.loops.foreach.limit"></td></tr>
@@ -78,12 +67,14 @@
     </table>
   </div>
 
-  <!-- inline children template -->
+  <!-- self-repeating pattern -->
   <div class="doc-section">
     <h2 class="doc-title" t="docs.loops.inline.title"></h2>
     <p class="doc-text" t="docs.loops.inline.text"></p>
-    <div class="code-block"><pre><span class="hl-tag">&lt;ul</span> <span class="hl-attr">foreach</span>=<span class="hl-str">"user in users"</span><span class="hl-tag">&gt;</span>
-  <span class="hl-tag">&lt;li</span> <span class="hl-attr">bind</span>=<span class="hl-str">"user.name"</span><span class="hl-tag">&gt;&lt;/li&gt;</span>
+    <div class="code-block"><pre><span class="hl-tag">&lt;ul&gt;</span>
+  <span class="hl-tag">&lt;li</span> <span class="hl-attr">foreach</span>=<span class="hl-str">"user in users"</span>
+      <span class="hl-attr">bind</span>=<span class="hl-str">"user.name"</span><span class="hl-tag">&gt;&lt;/li&gt;</span>
+  <span class="hl-tag">&lt;li</span> <span class="hl-attr">else</span><span class="hl-tag">&gt;</span>No users found<span class="hl-tag">&lt;/li&gt;</span>
 <span class="hl-tag">&lt;/ul&gt;</span></pre></div>
   </div>
 
@@ -92,9 +83,9 @@
     <h2 class="doc-title" t="docs.loops.aliases.title"></h2>
     <p class="doc-text" t="docs.loops.aliases.text"></p>
     <div class="code-block"><pre><span class="hl-cmt">&lt;!-- All three are identical: --&gt;</span>
-<span class="hl-tag">&lt;div</span> <span class="hl-attr">foreach</span>=<span class="hl-str">"item in items"</span> <span class="hl-attr">template</span>=<span class="hl-str">"tpl"</span><span class="hl-tag">&gt;&lt;/div&gt;</span>
-<span class="hl-tag">&lt;div</span> <span class="hl-attr">each</span>=<span class="hl-str">"item in items"</span> <span class="hl-attr">template</span>=<span class="hl-str">"tpl"</span><span class="hl-tag">&gt;&lt;/div&gt;</span>
-<span class="hl-tag">&lt;div</span> <span class="hl-attr">for</span>=<span class="hl-str">"item in items"</span> <span class="hl-attr">template</span>=<span class="hl-str">"tpl"</span><span class="hl-tag">&gt;&lt;/div&gt;</span></pre></div>
+<span class="hl-tag">&lt;div</span> <span class="hl-attr">foreach</span>=<span class="hl-str">"item in items"</span> <span class="hl-attr">bind</span>=<span class="hl-str">"item.name"</span><span class="hl-tag">&gt;&lt;/div&gt;</span>
+<span class="hl-tag">&lt;div</span> <span class="hl-attr">each</span>=<span class="hl-str">"item in items"</span> <span class="hl-attr">bind</span>=<span class="hl-str">"item.name"</span><span class="hl-tag">&gt;&lt;/div&gt;</span>
+<span class="hl-tag">&lt;div</span> <span class="hl-attr">for</span>=<span class="hl-str">"item in items"</span> <span class="hl-attr">bind</span>=<span class="hl-str">"item.name"</span><span class="hl-tag">&gt;&lt;/div&gt;</span></pre></div>
   </div>
 
   <!-- deprecated from -->
@@ -102,10 +93,10 @@
     <h2 class="doc-title" t="docs.loops.deprecated.title"></h2>
     <p class="doc-text" t="docs.loops.deprecated.text"></p>
     <div class="code-block"><pre><span class="hl-cmt">&lt;!-- DEPRECATED — still works, emits console warning --&gt;</span>
-<span class="hl-tag">&lt;div</span> <span class="hl-attr">foreach</span>=<span class="hl-str">"item"</span> <span class="hl-attr">from</span>=<span class="hl-str">"items"</span> <span class="hl-attr">template</span>=<span class="hl-str">"tpl"</span><span class="hl-tag">&gt;&lt;/div&gt;</span>
+<span class="hl-tag">&lt;div</span> <span class="hl-attr">foreach</span>=<span class="hl-str">"item"</span> <span class="hl-attr">from</span>=<span class="hl-str">"items"</span> <span class="hl-attr">bind</span>=<span class="hl-str">"item.name"</span><span class="hl-tag">&gt;&lt;/div&gt;</span>
 
 <span class="hl-cmt">&lt;!-- Use this instead: --&gt;</span>
-<span class="hl-tag">&lt;div</span> <span class="hl-attr">foreach</span>=<span class="hl-str">"item in items"</span> <span class="hl-attr">template</span>=<span class="hl-str">"tpl"</span><span class="hl-tag">&gt;&lt;/div&gt;</span></pre></div>
+<span class="hl-tag">&lt;div</span> <span class="hl-attr">foreach</span>=<span class="hl-str">"item in items"</span> <span class="hl-attr">bind</span>=<span class="hl-str">"item.name"</span><span class="hl-tag">&gt;&lt;/div&gt;</span></pre></div>
   </div>
 
   <!-- loop context variables -->
@@ -125,34 +116,24 @@
       </tbody>
     </table>
     <div class="code-block"><pre><span class="hl-tag">&lt;div</span> <span class="hl-attr">foreach</span>=<span class="hl-str">"item in items"</span>
-     <span class="hl-attr">template</span>=<span class="hl-str">"contextItem"</span><span class="hl-tag">&gt;&lt;/div&gt;</span>
-
-<span class="hl-tag">&lt;template</span> <span class="hl-attr">id</span>=<span class="hl-str">"contextItem"</span><span class="hl-tag">&gt;</span>
-  <span class="hl-tag">&lt;div</span> <span class="hl-attr">class-first</span>=<span class="hl-str">"$first"</span>
-       <span class="hl-attr">class-last</span>=<span class="hl-str">"$last"</span>
-       <span class="hl-attr">class-striped</span>=<span class="hl-str">"$odd"</span><span class="hl-tag">&gt;</span>
-    <span class="hl-tag">&lt;span</span> <span class="hl-attr">bind</span>=<span class="hl-str">"$index + 1"</span><span class="hl-tag">&gt;&lt;/span&gt;</span>. <span class="hl-tag">&lt;span</span> <span class="hl-attr">bind</span>=<span class="hl-str">"item.name"</span><span class="hl-tag">&gt;&lt;/span&gt;</span>
-  <span class="hl-tag">&lt;/div&gt;</span>
-<span class="hl-tag">&lt;/template&gt;</span></pre></div>
+     <span class="hl-attr">class-first</span>=<span class="hl-str">"$first"</span>
+     <span class="hl-attr">class-last</span>=<span class="hl-str">"$last"</span>
+     <span class="hl-attr">class-striped</span>=<span class="hl-str">"$odd"</span><span class="hl-tag">&gt;</span>
+  <span class="hl-tag">&lt;span</span> <span class="hl-attr">bind</span>=<span class="hl-str">"$index + 1"</span><span class="hl-tag">&gt;&lt;/span&gt;</span>. <span class="hl-tag">&lt;span</span> <span class="hl-attr">bind</span>=<span class="hl-str">"item.name"</span><span class="hl-tag">&gt;&lt;/span&gt;</span>
+<span class="hl-tag">&lt;/div&gt;</span></pre></div>
   </div>
 
   <!-- nested loops -->
   <div class="doc-section">
     <h2 class="doc-title" id="loops-nested" t="docs.loops.nested.title"></h2>
     <p class="doc-text" t="docs.loops.nested.text"></p>
-    <div class="code-block"><pre><span class="hl-tag">&lt;div</span> <span class="hl-attr">foreach</span>=<span class="hl-str">"category in categories"</span>
-     <span class="hl-attr">template</span>=<span class="hl-str">"categoryTpl"</span><span class="hl-tag">&gt;&lt;/div&gt;</span>
-
-<span class="hl-tag">&lt;template</span> <span class="hl-attr">id</span>=<span class="hl-str">"categoryTpl"</span><span class="hl-tag">&gt;</span>
+    <div class="code-block"><pre><span class="hl-tag">&lt;section</span> <span class="hl-attr">foreach</span>=<span class="hl-str">"category in categories"</span><span class="hl-tag">&gt;</span>
   <span class="hl-tag">&lt;h3</span> <span class="hl-attr">bind</span>=<span class="hl-str">"category.name"</span><span class="hl-tag">&gt;&lt;/h3&gt;</span>
-  <span class="hl-tag">&lt;div</span> <span class="hl-attr">foreach</span>=<span class="hl-str">"product in category.products"</span>
-       <span class="hl-attr">template</span>=<span class="hl-str">"productTpl"</span><span class="hl-tag">&gt;&lt;/div&gt;</span>
-<span class="hl-tag">&lt;/template&gt;</span>
-
-<span class="hl-tag">&lt;template</span> <span class="hl-attr">id</span>=<span class="hl-str">"productTpl"</span><span class="hl-tag">&gt;</span>
   <span class="hl-cmt">&lt;!-- Access both product AND category --&gt;</span>
-  <span class="hl-tag">&lt;p&gt;</span><span class="hl-tag">&lt;span</span> <span class="hl-attr">bind</span>=<span class="hl-str">"category.name"</span><span class="hl-tag">&gt;&lt;/span&gt;</span>: <span class="hl-tag">&lt;span</span> <span class="hl-attr">bind</span>=<span class="hl-str">"product.name"</span><span class="hl-tag">&gt;&lt;/span&gt;&lt;/p&gt;</span>
-<span class="hl-tag">&lt;/template&gt;</span></pre></div>
+  <span class="hl-tag">&lt;p</span> <span class="hl-attr">foreach</span>=<span class="hl-str">"product in category.products"</span><span class="hl-tag">&gt;</span>
+    <span class="hl-tag">&lt;span</span> <span class="hl-attr">bind</span>=<span class="hl-str">"category.name"</span><span class="hl-tag">&gt;&lt;/span&gt;</span>: <span class="hl-tag">&lt;span</span> <span class="hl-attr">bind</span>=<span class="hl-str">"product.name"</span><span class="hl-tag">&gt;&lt;/span&gt;</span>
+  <span class="hl-tag">&lt;/p&gt;</span>
+<span class="hl-tag">&lt;/section&gt;</span></pre></div>
   </div>
 
   <!-- Reactivity -->
@@ -160,9 +141,8 @@
     <h2 class="doc-title" id="loops-reactivity" t="docs.loops.reactivity.title"></h2>
     <p class="doc-text" t="docs.loops.reactivity.text"></p>
     <div class="code-block"><pre><span class="hl-tag">&lt;div</span> <span class="hl-attr">state</span>=<span class="hl-str">"{ items: ['A', 'B', 'C'] }"</span><span class="hl-tag">&gt;</span>
-  <span class="hl-tag">&lt;div</span> <span class="hl-attr">foreach</span>=<span class="hl-str">"item in items"</span> <span class="hl-attr">key</span>=<span class="hl-str">"item"</span><span class="hl-tag">&gt;</span>
-    <span class="hl-tag">&lt;span</span> <span class="hl-attr">bind</span>=<span class="hl-str">"item"</span><span class="hl-tag">&gt;&lt;/span&gt;</span>
-  <span class="hl-tag">&lt;/div&gt;</span>
+  <span class="hl-tag">&lt;span</span> <span class="hl-attr">foreach</span>=<span class="hl-str">"item in items"</span> <span class="hl-attr">key</span>=<span class="hl-str">"item"</span>
+        <span class="hl-attr">bind</span>=<span class="hl-str">"item"</span><span class="hl-tag">&gt;&lt;/span&gt;</span>
   <span class="hl-tag">&lt;button</span> <span class="hl-attr">on:click</span>=<span class="hl-str">"items.push('D')"</span><span class="hl-tag">&gt;</span>Add<span class="hl-tag">&lt;/button&gt;</span>
 <span class="hl-tag">&lt;/div&gt;</span></pre></div>
   </div>
@@ -172,9 +152,8 @@
     <h2 class="doc-title" id="loops-object-iteration" t="docs.loops.objectIteration.title"></h2>
     <p class="doc-text" t="docs.loops.objectIteration.text"></p>
     <div class="code-block"><pre><span class="hl-tag">&lt;div</span> <span class="hl-attr">state</span>=<span class="hl-str">"{ config: { theme: 'dark', lang: 'en' } }"</span><span class="hl-tag">&gt;</span>
-  <span class="hl-tag">&lt;div</span> <span class="hl-attr">foreach</span>=<span class="hl-str">"key in config | keys"</span><span class="hl-tag">&gt;</span>
-    <span class="hl-tag">&lt;span</span> <span class="hl-attr">bind</span>=<span class="hl-str">"key"</span><span class="hl-tag">&gt;&lt;/span&gt;</span>
-  <span class="hl-tag">&lt;/div&gt;</span>
+  <span class="hl-tag">&lt;span</span> <span class="hl-attr">foreach</span>=<span class="hl-str">"key in config | keys"</span>
+        <span class="hl-attr">bind</span>=<span class="hl-str">"key"</span><span class="hl-tag">&gt;&lt;/span&gt;</span>
 <span class="hl-tag">&lt;/div&gt;</span></pre></div>
     <div class="callout">
       <p t="docs.loops.objectIteration.callout"></p>

--- a/docs/templates/docs/pagination.tpl
+++ b/docs/templates/docs/pagination.tpl
@@ -163,6 +163,7 @@
   <span class="hl-tag">&lt;div</span> <span class="hl-attr">foreach</span>=<span class="hl-str">"item in items"</span><span class="hl-tag">&gt;</span>
     <span class="hl-tag">&lt;p</span> <span class="hl-attr">bind</span>=<span class="hl-str">"item.name"</span><span class="hl-tag">&gt;&lt;/p&gt;</span>
   <span class="hl-tag">&lt;/div&gt;</span>
+  <span class="hl-tag">&lt;p</span> <span class="hl-attr">else</span><span class="hl-tag">&gt;</span>No items found<span class="hl-tag">&lt;/p&gt;</span>
 <span class="hl-tag">&lt;/div&gt;</span></pre></div>
     <div class="demo-note" t="docs.pagination.quickStart.note"></div>
   </div>

--- a/docs/templates/examples.tpl
+++ b/docs/templates/examples.tpl
@@ -339,9 +339,9 @@
        <span class="hl-attr">loading</span>=<span class="hl-str">"#dash-skeleton"</span><span class="hl-tag">&gt;</span>
     <span class="hl-tag">&lt;h2</span> <span class="hl-attr">bind</span>=<span class="hl-str">"'Welcome, ' + data.user.name"</span><span class="hl-tag">&gt;&lt;/h2&gt;</span>
     <span class="hl-tag">&lt;div</span> <span class="hl-attr">each</span>=<span class="hl-str">"m in data.metrics"</span><span class="hl-tag">&gt;</span>
-      <span class="hl-tag">&lt;span</span> <span class="hl-attr">bind</span>=<span class="hl-str">"m.label"</span><span class="hl-tag">&gt;&lt;/span&gt;</span>
-      <span class="hl-tag">&lt;span</span> <span class="hl-attr">bind</span>=<span class="hl-str">"m.value | number"</span><span class="hl-tag">&gt;&lt;/span&gt;</span>
+      <span class="hl-tag">&lt;span</span> <span class="hl-attr">bind</span>=<span class="hl-str">"m.label"</span><span class="hl-tag">&gt;&lt;/span&gt;</span> <span class="hl-tag">&lt;span</span> <span class="hl-attr">bind</span>=<span class="hl-str">"m.value | number"</span><span class="hl-tag">&gt;&lt;/span&gt;</span>
     <span class="hl-tag">&lt;/div&gt;</span>
+    <span class="hl-tag">&lt;p</span> <span class="hl-attr">else</span><span class="hl-tag">&gt;</span>No metrics available<span class="hl-tag">&lt;/p&gt;</span>
   <span class="hl-tag">&lt;/div&gt;</span>
   <span class="hl-tag">&lt;button</span> <span class="hl-attr">on:click</span>=<span class="hl-str">"$store.auth.user = null;
     $store.auth.token = null"</span><span class="hl-tag">&gt;</span>
@@ -411,9 +411,9 @@
     <span class="hl-tag">&lt;/p&gt;</span>
 
     <span class="hl-tag">&lt;div</span> <span class="hl-attr">each</span>=<span class="hl-str">"item in results"</span><span class="hl-tag">&gt;</span>
-      <span class="hl-tag">&lt;span</span> <span class="hl-attr">bind</span>=<span class="hl-str">"item.name"</span><span class="hl-tag">&gt;&lt;/span&gt;</span>
-      <span class="hl-tag">&lt;span</span> <span class="hl-attr">bind</span>=<span class="hl-str">"item.price | currency"</span><span class="hl-tag">&gt;&lt;/span&gt;</span>
+      <span class="hl-tag">&lt;span</span> <span class="hl-attr">bind</span>=<span class="hl-str">"item.name"</span><span class="hl-tag">&gt;&lt;/span&gt;</span> <span class="hl-tag">&lt;span</span> <span class="hl-attr">bind</span>=<span class="hl-str">"item.price | currency"</span><span class="hl-tag">&gt;&lt;/span&gt;</span>
     <span class="hl-tag">&lt;/div&gt;</span>
+    <span class="hl-tag">&lt;p</span> <span class="hl-attr">else</span><span class="hl-tag">&gt;</span>No results<span class="hl-tag">&lt;/p&gt;</span>
 
   <span class="hl-tag">&lt;/div&gt;</span>
 <span class="hl-tag">&lt;/div&gt;</span></pre>
@@ -484,6 +484,7 @@
       Add to cart
     <span class="hl-tag">&lt;/button&gt;</span>
   <span class="hl-tag">&lt;/div&gt;</span>
+  <span class="hl-tag">&lt;p</span> <span class="hl-attr">else</span><span class="hl-tag">&gt;</span>No products available<span class="hl-tag">&lt;/p&gt;</span>
 <span class="hl-tag">&lt;/div&gt;</span>
 
 <span class="hl-cmt">&lt;!-- Cart summary: elsewhere in the page --&gt;</span>
@@ -574,9 +575,9 @@
   <span class="hl-tag">&lt;/span&gt;</span>
 
   <span class="hl-tag">&lt;div</span> <span class="hl-attr">each</span>=<span class="hl-str">"metric in s.metrics"</span><span class="hl-tag">&gt;</span>
-    <span class="hl-tag">&lt;span</span> <span class="hl-attr">bind</span>=<span class="hl-str">"metric.label"</span><span class="hl-tag">&gt;&lt;/span&gt;</span>
-    <span class="hl-tag">&lt;span</span> <span class="hl-attr">bind</span>=<span class="hl-str">"metric.value | number"</span><span class="hl-tag">&gt;&lt;/span&gt;</span>
+    <span class="hl-tag">&lt;span</span> <span class="hl-attr">bind</span>=<span class="hl-str">"metric.label"</span><span class="hl-tag">&gt;&lt;/span&gt;</span> <span class="hl-tag">&lt;span</span> <span class="hl-attr">bind</span>=<span class="hl-str">"metric.value | number"</span><span class="hl-tag">&gt;&lt;/span&gt;</span>
   <span class="hl-tag">&lt;/div&gt;</span>
+  <span class="hl-tag">&lt;p</span> <span class="hl-attr">else</span><span class="hl-tag">&gt;</span>No metrics<span class="hl-tag">&lt;/p&gt;</span>
 
 <span class="hl-tag">&lt;/div&gt;</span></pre>
     </div>

--- a/docs/templates/features.tpl
+++ b/docs/templates/features.tpl
@@ -231,9 +231,11 @@
       </div>
     </div>
     <div class="code-block">
-      <pre><span class="hl-tag">&lt;ul</span> <span class="hl-attr">each</span>=<span class="hl-str">"item in items"</span><span class="hl-tag">&gt;</span>
-  <span class="hl-line-highlight"><span class="hl-tag">&lt;li</span> <span class="hl-attr">bind</span>=<span class="hl-str">"item.name"</span></span>
+      <pre><span class="hl-tag">&lt;ul&gt;</span>
+  <span class="hl-line-highlight"><span class="hl-tag">&lt;li</span> <span class="hl-attr">each</span>=<span class="hl-str">"item in items"</span></span>
+<span class="hl-line-highlight">      <span class="hl-attr">bind</span>=<span class="hl-str">"item.name"</span></span>
 <span class="hl-line-highlight">      <span class="hl-attr">if</span>=<span class="hl-str">"item.active"</span><span class="hl-tag">&gt;&lt;/li&gt;</span></span>
+  <span class="hl-tag">&lt;li</span> <span class="hl-attr">else</span><span class="hl-tag">&gt;</span>No items<span class="hl-tag">&lt;/li&gt;</span>
 <span class="hl-tag">&lt;/ul&gt;</span></pre>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- Convert all loop code examples from container pattern (`<ul each="item in items"><li>...</li></ul>`) to self-repeating pattern (`<ul><li each="item in items">...</li></ul>`) across all doc templates
- Add sibling `else` examples where appropriate (`<li else>No items found</li>`)
- Update i18n translations in all 5 locales (en, pt, es, fr, it) to describe the new self-repeating pattern and sibling else behavior
- Add `else` (sibling) row to the cheatsheet loops table in all locales

## Files changed (14)

**Templates (8):**
- `docs/templates/docs/loops.tpl` — Main loops documentation page (all examples converted)
- `docs/templates/features.tpl` — Showcase 2 loop snippet
- `docs/templates/examples.tpl` — Dashboard, search, cart, polling examples
- `docs/templates/docs/pagination.tpl` — Pagination quick start + sibling else
- `docs/templates/docs/animations.tpl` — Loop animations (removed template attr)
- `docs/templates/docs/cheatsheet.tpl` — Added else (sibling) row
- `docs/templates/docs/getting-started.tpl` — Context diagram comment

**Playground (2):**
- `docs/playground/examples/kanban.html` — Comment update
- `docs/playground/examples/chat.html` — Comment update

**i18n (5):**
- `docs/locales/{en,pt,es,fr,it}/docs.json` — Updated loops.foreach.text, loops.foreach.else, loops.fullExample.text, loops.inline.title+text, cheatsheet.loops.else

## Test plan
- [ ] Verify docs site renders correctly at `npm start` on port 3000
- [ ] Check loops documentation page shows self-repeating pattern examples
- [ ] Verify cheatsheet shows the new else (sibling) row
- [ ] Switch locale to pt/es/fr/it and verify translations render
- [ ] Validate all JSON locale files parse without errors