### PR TITLE
docs(loops): update markdown docs for loop else patterns (NOJS-129)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - First-fetch sentinel registers `_onDispose` — fixes leak on element removal before pagination ([b32fb35](https://github.com/ErickXavier/no-js/commit/b32fb35))
 - `_removeInlineError()` helper added for proper error wrapper cleanup ([b32fb35](https://github.com/ErickXavier/no-js/commit/b32fb35))
 - `fetch.js`: expose response headers via `meta` before `_REPLACE` early return ([b32fb35](https://github.com/ErickXavier/no-js/commit/b32fb35))
+- Conditionals: guard `else` directive from firing on loop elements that use `else="templateId"` for empty-state rendering — the conditional handler now skips elements with `foreach`, `each`, or `for` attributes ([b24b6e9](https://github.com/ErickXavier/no-js/commit/b24b6e9))
 
 ## [1.13.3] - 2026-06-05
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,7 @@ No linter configured.
 - **registry.js** — Directive registration via `registerDirective(name, handler)`. Core directives frozen after init — plugins can add but not override.
 - **filters.js** — 32+ built-in filters (currency, date, uppercase, etc.). Self-register on import. Custom: `NoJS.filter('name', fn)`.
 - **directives/** — 15+ directive files organized by category (state, http, binding, conditionals, loops, styling, events, refs, validation, i18n, dnd, head, animations). One file per category, side-effect imports for registration.
+  - **Loop/else patterns:** loop directives (`foreach`, `each`, `for`) support empty-state rendering via a sibling `else` element or an inline `else="templateId"` attribute on the loop element itself. The conditional `else` handler skips elements that carry a loop directive.
 
 ### Directive priority order
 

--- a/docs/md/conditionals.md
+++ b/docs/md/conditionals.md
@@ -106,6 +106,18 @@ The `else` directive also works as a **sibling element after a loop**. When the 
 </ul>
 ```
 
+You can also place `else` directly on the loop element as an attribute with a template reference:
+
+```html
+<article foreach="item in items" else="noItems">
+  <h2 bind="item.title"></h2>
+</article>
+
+<template id="noItems">
+  <p>No items found.</p>
+</template>
+```
+
 This complements the conditional `if`/`else` pattern — `else` now works in both contexts. See [Loops](loops.md) for full details.
 
 ---

--- a/docs/md/loops.md
+++ b/docs/md/loops.md
@@ -74,7 +74,7 @@ When the source array is empty, `null`, or `undefined`, the loop renders nothing
 
 The `else` element is hidden when items exist and shown when the list is empty. This works with all three aliases (`foreach`, `each`, `for`).
 
-You can also reference an external template with `else="templateId"`:
+You can also reference an external template with `else="templateId"` on the sibling:
 
 ```html
 <ul>
@@ -90,11 +90,28 @@ You can also reference an external template with `else="templateId"`:
 </template>
 ```
 
+### Inline `else` on the Loop Element
+
+Instead of a sibling, you can place the `else` attribute directly on the loop element with a template reference. When the list is empty, the referenced template content replaces the loop:
+
+```html
+<article foreach="item in items" else="noItems">
+  <h2 bind="item.title"></h2>
+</article>
+
+<template id="noItems">
+  <p class="empty-state">No items found.</p>
+</template>
+```
+
+Both patterns produce the same result — use the sibling form when you want inline fallback content, and the inline `else` attribute when you want to reference a shared template.
+
 ### Attributes
 
 | Attribute | Description |
 |-----------|-------------|
 | `foreach` | `"item in array"` — variable name and source expression |
+| `else` | Template ID for empty-state content rendered when the list is empty (alternative to a sibling `else` element) |
 | `template` | ID of the `<template>` element to clone for each item (optional — when omitted, the element's own children are the template) |
 | `index` | Variable name for the index (default: `$index`) |
 | `key` | Unique key expression for DOM diffing |
@@ -107,7 +124,7 @@ You can also reference an external template with `else="templateId"`:
 | `animate-stagger` | Delay (ms) between each item's enter animation |
 | `animate-duration` | Max duration (ms) before leave animation is force-completed |
 
-The sibling `else` element is documented above — it is placed after the loop element, not as an attribute on it.
+Empty-state rendering supports two patterns: a **sibling element** with the `else` attribute (documented above), or an **inline `else` attribute** on the loop element itself referencing a template ID.
 
 ---
 


### PR DESCRIPTION
## Summary
- Document the inline `else="#templateId"` pattern on loop elements in `loops.md` and `conditionals.md`
- Update `CLAUDE.md` with loop/else pattern note in directives section
- Add CHANGELOG entry for the else directive guard fix

## Test plan
- [ ] Verify markdown renders correctly on GitHub
- [ ] Cross-reference with loops.js implementation