### PR TITLE
test(loops): add E2E tests for loop else patterns (NOJS-128)

### DIFF
--- a/e2e/examples/loops.html
+++ b/e2e/examples/loops.html
@@ -124,6 +124,46 @@
     </ul>
   </section>
 
+  <!-- 13. foreach with sibling else — toggle between empty and populated -->
+  <section state="{ feItems: [], feAll: ['X', 'Y', 'Z'] }">
+    <p class="test-label">Test 13: foreach sibling else with toggle</p>
+    <button data-test="fe-sib-toggle" on:click="feItems = feItems.length > 0 ? [] : feAll">Toggle</button>
+    <ul data-test="fe-sib-list">
+      <li data-test="fe-sib-item" foreach="item in feItems" bind="item"></li>
+      <li data-test="fe-sib-else" else>No data available</li>
+    </ul>
+  </section>
+
+  <!-- 14. foreach with else template reference — toggle between empty and populated -->
+  <section state="{ feTplItems: [], feTplAll: [{name: 'Alpha'}, {name: 'Beta'}] }">
+    <p class="test-label">Test 14: foreach else template with toggle</p>
+    <button data-test="fe-tpl-toggle" on:click="feTplItems = feTplItems.length > 0 ? [] : feTplAll">Toggle</button>
+    <ul data-test="fe-tpl-list">
+      <li data-test="fe-tpl-item" foreach="item in feTplItems" else="fe-no-data" bind="item.name"></li>
+    </ul>
+    <template id="fe-no-data"><p data-test="fe-tpl-else">No records found</p></template>
+  </section>
+
+  <!-- 15. each with else template reference — toggle between empty and populated -->
+  <section state="{ eaTplItems: [], eaTplAll: ['One', 'Two', 'Three'] }">
+    <p class="test-label">Test 15: each else template with toggle</p>
+    <button data-test="ea-tpl-toggle" on:click="eaTplItems = eaTplItems.length > 0 ? [] : eaTplAll">Toggle</button>
+    <ul data-test="ea-tpl-list">
+      <li data-test="ea-tpl-item" each="item in eaTplItems" else="ea-no-data" bind="item"></li>
+    </ul>
+    <template id="ea-no-data"><p data-test="ea-tpl-else">Nothing here</p></template>
+  </section>
+
+  <!-- 16. for with else template reference — toggle between empty and populated -->
+  <section state="{ frTplItems: [], frTplAll: [100, 200, 300] }">
+    <p class="test-label">Test 16: for else template with toggle</p>
+    <button data-test="fr-tpl-toggle" on:click="frTplItems = frTplItems.length > 0 ? [] : frTplAll">Toggle</button>
+    <ul data-test="fr-tpl-list">
+      <li data-test="fr-tpl-item" for="item in frTplItems" else="fr-no-data" bind="item"></li>
+    </ul>
+    <template id="fr-no-data"><p data-test="fr-tpl-else">Empty list</p></template>
+  </section>
+
   <script src="../../dist/iife/no.js"></script>
   <!--
     WORKAROUND: processTree(document.body) breaks when a self-repeating loop

--- a/e2e/tests/loops.spec.ts
+++ b/e2e/tests/loops.spec.ts
@@ -159,4 +159,144 @@ test.describe('Loops', () => {
     await expect(items.nth(1)).toHaveText('Gadget');
     await expect(items.nth(2)).toHaveText('Doohickey');
   });
+
+  test('13 — foreach sibling else: shows else when array is initially empty', async ({ page }) => {
+    const items = page.getByTestId('fe-sib-item');
+    const elseEl = page.getByTestId('fe-sib-else');
+
+    // Initially empty — else content visible, no loop items
+    await expect(items).toHaveCount(0);
+    await expect(elseEl).toBeVisible();
+    await expect(elseEl).toHaveText('No data available');
+  });
+
+  // FIXME: same framework bug as test 3 — disconnected watcher element prevents
+  // the loop from re-rendering when state changes dynamically.
+  test.fixme('13 — foreach sibling else: toggles between items and else', async ({ page }) => {
+    const items = page.getByTestId('fe-sib-item');
+    const elseEl = page.getByTestId('fe-sib-else');
+
+    // Initially empty — else visible
+    await expect(items).toHaveCount(0);
+    await expect(elseEl).toBeVisible();
+
+    // Toggle to populated — items appear, else hides
+    await page.getByTestId('fe-sib-toggle').click();
+    await expect(items).toHaveCount(3);
+    await expect(items.nth(0)).toHaveText('X');
+    await expect(items.nth(1)).toHaveText('Y');
+    await expect(items.nth(2)).toHaveText('Z');
+    await expect(elseEl).toBeHidden();
+
+    // Toggle back to empty — else reappears
+    await page.getByTestId('fe-sib-toggle').click();
+    await expect(items).toHaveCount(0);
+    await expect(elseEl).toBeVisible();
+
+    // Toggle to populated again — verifies multiple round-trips
+    await page.getByTestId('fe-sib-toggle').click();
+    await expect(items).toHaveCount(3);
+    await expect(elseEl).toBeHidden();
+  });
+
+  test('14 — foreach else template: shows template content when array is initially empty', async ({ page }) => {
+    const items = page.getByTestId('fe-tpl-item');
+    const elseEl = page.getByTestId('fe-tpl-else');
+
+    // Initially empty — template else content injected
+    await expect(items).toHaveCount(0);
+    await expect(elseEl).toBeVisible();
+    await expect(elseEl).toHaveText('No records found');
+  });
+
+  // FIXME: same framework bug as test 3 — disconnected watcher element prevents
+  // the loop from re-rendering when state changes dynamically.
+  test.fixme('14 — foreach else template: toggles between items and template else', async ({ page }) => {
+    const items = page.getByTestId('fe-tpl-item');
+    const elseEl = page.getByTestId('fe-tpl-else');
+
+    // Initially empty — template else visible
+    await expect(items).toHaveCount(0);
+    await expect(elseEl).toBeVisible();
+
+    // Toggle to populated — items appear, else template removed
+    await page.getByTestId('fe-tpl-toggle').click();
+    await expect(items).toHaveCount(2);
+    await expect(items.nth(0)).toHaveText('Alpha');
+    await expect(items.nth(1)).toHaveText('Beta');
+    await expect(elseEl).toHaveCount(0);
+
+    // Toggle back to empty — template else reappears
+    await page.getByTestId('fe-tpl-toggle').click();
+    await expect(items).toHaveCount(0);
+    await expect(elseEl).toBeVisible();
+  });
+
+  test('15 — each else template: shows template content when array is initially empty', async ({ page }) => {
+    const items = page.getByTestId('ea-tpl-item');
+    const elseEl = page.getByTestId('ea-tpl-else');
+
+    // Initially empty — template else content injected
+    await expect(items).toHaveCount(0);
+    await expect(elseEl).toBeVisible();
+    await expect(elseEl).toHaveText('Nothing here');
+  });
+
+  // FIXME: same framework bug as test 3 — disconnected watcher element prevents
+  // the loop from re-rendering when state changes dynamically.
+  test.fixme('15 — each else template: toggles between items and template else', async ({ page }) => {
+    const items = page.getByTestId('ea-tpl-item');
+    const elseEl = page.getByTestId('ea-tpl-else');
+
+    // Initially empty — template else visible
+    await expect(items).toHaveCount(0);
+    await expect(elseEl).toBeVisible();
+
+    // Toggle to populated — items appear, else removed
+    await page.getByTestId('ea-tpl-toggle').click();
+    await expect(items).toHaveCount(3);
+    await expect(items.nth(0)).toHaveText('One');
+    await expect(items.nth(1)).toHaveText('Two');
+    await expect(items.nth(2)).toHaveText('Three');
+    await expect(elseEl).toHaveCount(0);
+
+    // Toggle back to empty — template else reappears
+    await page.getByTestId('ea-tpl-toggle').click();
+    await expect(items).toHaveCount(0);
+    await expect(elseEl).toBeVisible();
+  });
+
+  test('16 — for else template: shows template content when array is initially empty', async ({ page }) => {
+    const items = page.getByTestId('fr-tpl-item');
+    const elseEl = page.getByTestId('fr-tpl-else');
+
+    // Initially empty — template else content injected
+    await expect(items).toHaveCount(0);
+    await expect(elseEl).toBeVisible();
+    await expect(elseEl).toHaveText('Empty list');
+  });
+
+  // FIXME: same framework bug as test 3 — disconnected watcher element prevents
+  // the loop from re-rendering when state changes dynamically.
+  test.fixme('16 — for else template: toggles between items and template else', async ({ page }) => {
+    const items = page.getByTestId('fr-tpl-item');
+    const elseEl = page.getByTestId('fr-tpl-else');
+
+    // Initially empty — template else visible
+    await expect(items).toHaveCount(0);
+    await expect(elseEl).toBeVisible();
+
+    // Toggle to populated — items appear, else removed
+    await page.getByTestId('fr-tpl-toggle').click();
+    await expect(items).toHaveCount(3);
+    await expect(items.nth(0)).toHaveText('100');
+    await expect(items.nth(1)).toHaveText('200');
+    await expect(items.nth(2)).toHaveText('300');
+    await expect(elseEl).toHaveCount(0);
+
+    // Toggle back to empty — template else reappears
+    await page.getByTestId('fr-tpl-toggle').click();
+    await expect(items).toHaveCount(0);
+    await expect(elseEl).toBeVisible();
+  });
 });


### PR DESCRIPTION
## Summary
- Add 4 fixture sections (13-16) in `e2e/examples/loops.html` for loop/else patterns
- Add 8 Playwright specs covering foreach/each/for with sibling else and template else
- Toggle tests marked `test.fixme` due to known watcher disconnect issue on self-repeating loops

## Test plan
- [ ] `npx playwright test e2e/tests/loops.spec.ts` — non-fixme tests pass
- [ ] Fixture renders correctly in browser at localhost:3000/e2e/examples/loops.html