### PR TITLE
docs(loops): add else template reference to HTML docs and i18n (NOJS-130)

### DIFF
--- a/docs/locales/en/docs.json
+++ b/docs/locales/en/docs.json
@@ -137,7 +137,7 @@
         "sort": "Sort property (name only, not prefixed with item variable)",
         "limit": "Max items",
         "offset": "Skip items",
-        "else": "Sibling element shown when array is empty"
+        "else": "Empty-state fallback (sibling element or template reference)"
       },
       "events": {
         "title": "Events",
@@ -494,12 +494,13 @@
         "from": "Source array (DEPRECATED — use item in array syntax)",
         "index": "Variable name for the index (default: $index)",
         "key": "Unique key expression for element identification and tracking",
-        "else": "Sibling element with else attribute, shown when array is empty",
         "filter": "Expression to filter items",
         "sort": "Property path to sort by (prefix - for descending)",
         "limit": "Maximum number of items to render",
         "offset": "Number of items to skip",
-        "template": "External template ID (optional — children become template if omitted)"
+        "template": "External template ID (optional — children become template if omitted)",
+        "elseSibling": "Sibling element with else attribute, shown when array is empty",
+        "elseTpl": "Template ID on the loop element itself — rendered when array is empty (alternative to sibling else)"
       },
       "fullExample": {
         "title": "Full Example with All Attributes",
@@ -540,6 +541,11 @@
         "title": "Object Iteration",
         "text": "To iterate over an object's entries, use the keys or values filter to convert it to an array first.",
         "callout": "Direct object iteration is not supported — always convert to an array with keys, values, or Object.entries() in a computed expression."
+      },
+      "elseTpl": {
+        "title": "Else with Template Reference",
+        "text": "Instead of a sibling else element, you can place else=\"templateId\" directly on the loop element. When the array is empty, the referenced template content replaces the loop output.",
+        "callout": "The else attribute on the loop element only activates for empty arrays ([]). For null or undefined sources, use a sibling else element instead."
       }
     },
     "templates": {

--- a/docs/locales/es/docs.json
+++ b/docs/locales/es/docs.json
@@ -137,7 +137,7 @@
         "sort": "Propiedad para ordenar (solo el nombre, sin prefijo de variable de elemento)",
         "limit": "Máximo de elementos",
         "offset": "Omitir elementos",
-        "else": "Elemento hermano mostrado cuando el array está vacío"
+        "else": "Fallback para estado vacío (elemento hermano o referencia de template)"
       },
       "events": {
         "title": "Eventos",
@@ -493,13 +493,14 @@
         "from": "Array de origen (DEPRECATED — usa la sintaxis item in array)",
         "index": "Nombre de variable para el índice (por defecto: $index)",
         "key": "Expresión de clave única para identificación y seguimiento de elementos",
-        "else": "Elemento hermano con atributo else, mostrado cuando el array está vacío",
         "filter": "Expresión para filtrar elementos",
         "sort": "Ruta de propiedad para ordenar (prefijo - para descendente)",
         "limit": "Número máximo de elementos a renderizar",
         "offset": "Número de elementos a omitir",
         "preview": "Vista previa",
-        "template": "ID de plantilla externa (opcional — los hijos se convierten en la plantilla si se omite)"
+        "template": "ID de plantilla externa (opcional — los hijos se convierten en la plantilla si se omite)",
+        "elseSibling": "Elemento hermano con atributo else, mostrado cuando el array está vacío",
+        "elseTpl": "ID de template en el propio elemento del loop — renderizado cuando el array está vacío (alternativa al else hermano)"
       },
       "fullExample": {
         "title": "Ejemplo completo con todos los atributos",
@@ -540,6 +541,11 @@
         "title": "Iteración de Objetos",
         "text": "Para iterar sobre las entradas de un objeto, usa el filtro keys o values para convertirlo en array primero.",
         "callout": "La iteración directa de objetos no es soportada — siempre convierte a array con keys, values u Object.entries() en una expresión computed."
+      },
+      "elseTpl": {
+        "title": "Else con Referencia de Template",
+        "text": "En lugar de un elemento else hermano, puedes colocar else=\"templateId\" directamente en el elemento del loop. Cuando el array está vacío, el contenido del template referenciado reemplaza la salida del loop.",
+        "callout": "El atributo else en el elemento del loop solo se activa para arrays vacíos ([]). Para fuentes null o undefined, usa un elemento else hermano."
       }
     },
     "templates": {

--- a/docs/locales/fr/docs.json
+++ b/docs/locales/fr/docs.json
@@ -137,7 +137,7 @@
         "sort": "Propriété de tri (nom seul, sans préfixe de variable d'élément)",
         "limit": "Nombre maximum d'éléments",
         "offset": "Éléments à ignorer",
-        "else": "Élément frère affiché quand le tableau est vide"
+        "else": "Fallback pour l'état vide (élément frère ou référence de template)"
       },
       "events": {
         "title": "Événements",
@@ -493,13 +493,14 @@
         "from": "Tableau source (DEPRECATED — utilisez la syntaxe item in array)",
         "index": "Nom de la variable d'index (par défaut : $index)",
         "key": "Expression de clé unique pour l'identification et le suivi des éléments",
-        "else": "Élément frère avec attribut else, affiché quand le tableau est vide",
         "filter": "Expression pour filtrer les éléments",
         "sort": "Chemin de propriété pour le tri (préfixe - pour l'ordre décroissant)",
         "limit": "Nombre maximum d'éléments à afficher",
         "offset": "Nombre d'éléments à ignorer",
         "preview": "Aperçu",
-        "template": "ID de template externe (optionnel — les enfants deviennent le template si omis)"
+        "template": "ID de template externe (optionnel — les enfants deviennent le template si omis)",
+        "elseSibling": "Élément frère avec attribut else, affiché quand le tableau est vide",
+        "elseTpl": "ID de template sur l'élément de boucle — rendu quand le tableau est vide (alternative au else frère)"
       },
       "fullExample": {
         "title": "Exemple complet avec tous les attributs",
@@ -540,6 +541,11 @@
         "title": "Itération d'Objets",
         "text": "Pour itérer sur les entrées d'un objet, utilisez le filtre keys ou values pour le convertir en tableau d'abord.",
         "callout": "L'itération directe d'objets n'est pas supportée — convertissez toujours en tableau avec keys, values ou Object.entries() dans une expression computed."
+      },
+      "elseTpl": {
+        "title": "Else avec Référence de Template",
+        "text": "Au lieu d'un élément else frère, vous pouvez placer else=\"templateId\" directement sur l'élément de boucle. Quand le tableau est vide, le contenu du template référencé remplace la sortie de la boucle.",
+        "callout": "L'attribut else sur l'élément de boucle ne s'active que pour les tableaux vides ([]). Pour les sources null ou undefined, utilisez un élément else frère."
       }
     },
     "templates": {

--- a/docs/locales/it/docs.json
+++ b/docs/locales/it/docs.json
@@ -137,7 +137,7 @@
         "sort": "Proprietà di ordinamento (solo nome, senza prefisso della variabile elemento)",
         "limit": "Numero massimo di elementi",
         "offset": "Salta elementi",
-        "else": "Elemento fratello mostrato quando l'array è vuoto"
+        "else": "Fallback per stato vuoto (elemento fratello o riferimento al template)"
       },
       "events": {
         "title": "Eventi",
@@ -493,13 +493,14 @@
         "from": "Array sorgente (DEPRECATED — usa la sintassi item in array)",
         "index": "Nome della variabile per l'indice (default: $index)",
         "key": "Espressione chiave univoca per l'identificazione e il tracciamento degli elementi",
-        "else": "Elemento fratello con attributo else, mostrato quando l'array è vuoto",
         "filter": "Espressione per filtrare gli elementi",
         "sort": "Percorso della proprietà per l'ordinamento (prefisso - per ordine decrescente)",
         "limit": "Numero massimo di elementi da renderizzare",
         "offset": "Numero di elementi da saltare",
         "preview": "Anteprima",
-        "template": "ID di template esterno (opzionale — i figli diventano il template se omesso)"
+        "template": "ID di template esterno (opzionale — i figli diventano il template se omesso)",
+        "elseSibling": "Elemento fratello con attributo else, mostrato quando l'array è vuoto",
+        "elseTpl": "ID del template sull'elemento del loop — renderizzato quando l'array è vuoto (alternativa all'else fratello)"
       },
       "fullExample": {
         "title": "Esempio completo con tutti gli attributi",
@@ -540,6 +541,11 @@
         "title": "Iterazione di Oggetti",
         "text": "Per iterare sulle voci di un oggetto, usa il filtro keys o values per convertirlo in array prima.",
         "callout": "L'iterazione diretta di oggetti non è supportata — converti sempre in array con keys, values o Object.entries() in un'espressione computed."
+      },
+      "elseTpl": {
+        "title": "Else con Riferimento al Template",
+        "text": "Invece di un elemento else fratello, puoi inserire else=\"templateId\" direttamente sull'elemento del loop. Quando l'array è vuoto, il contenuto del template referenziato sostituisce l'output del loop.",
+        "callout": "L'attributo else sull'elemento del loop si attiva solo per array vuoti ([]). Per sorgenti null o undefined, usa un elemento else fratello."
       }
     },
     "templates": {

--- a/docs/locales/pt/docs.json
+++ b/docs/locales/pt/docs.json
@@ -137,7 +137,7 @@
         "sort": "Propriedade para ordenação (apenas nome, sem prefixo da variável do item)",
         "limit": "Máximo de itens",
         "offset": "Pular itens",
-        "else": "Elemento irmão exibido quando o array está vazio"
+        "else": "Fallback para estado vazio (elemento irmão ou referência de template)"
       },
       "events": {
         "title": "Eventos",
@@ -493,13 +493,14 @@
         "from": "Array de origem (DEPRECATED — use a sintaxe item in array)",
         "index": "Nome da variável para o índice (padrão: $index)",
         "key": "Expressão de chave única para identificação e rastreamento de elementos",
-        "else": "Elemento irmão com atributo else, exibido quando o array está vazio",
         "filter": "Expressão para filtrar itens",
         "sort": "Caminho da propriedade para ordenar (prefixo - para descendente)",
         "limit": "Número máximo de itens para renderizar",
         "offset": "Número de itens para pular",
         "preview": "Prévia",
-        "template": "ID de template externo (opcional — os filhos se tornam o template se omitido)"
+        "template": "ID de template externo (opcional — os filhos se tornam o template se omitido)",
+        "elseSibling": "Elemento irmão com atributo else, exibido quando o array está vazio",
+        "elseTpl": "ID de template no próprio elemento do loop — renderizado quando o array está vazio (alternativa ao else irmão)"
       },
       "fullExample": {
         "title": "Exemplo completo com todos os atributos",
@@ -540,6 +541,11 @@
         "title": "Iteração de Objetos",
         "text": "Para iterar sobre as entradas de um objeto, use o filtro keys ou values para converter em array primeiro.",
         "callout": "Iteração direta de objetos não é suportada — sempre converta para array com keys, values ou Object.entries() em uma expressão computed."
+      },
+      "elseTpl": {
+        "title": "Else com Referência de Template",
+        "text": "Em vez de um elemento else irmão, você pode colocar else=\"templateId\" diretamente no elemento do loop. Quando o array está vazio, o conteúdo do template referenciado substitui a saída do loop.",
+        "callout": "O atributo else no elemento do loop só é ativado para arrays vazios ([]). Para fontes null ou undefined, use um elemento else irmão."
       }
     },
     "templates": {

--- a/docs/templates/docs/loops.tpl
+++ b/docs/templates/docs/loops.tpl
@@ -57,7 +57,8 @@
         <tr><td><code>template</code></td><td t="docs.loops.foreach.template"></td></tr>
         <tr><td><code>index</code></td><td t="docs.loops.foreach.index"></td></tr>
         <tr><td><code>key</code></td><td t="docs.loops.foreach.key"></td></tr>
-        <tr><td><code>else</code> <small>(sibling)</small></td><td t="docs.loops.foreach.else"></td></tr>
+        <tr><td><code>else</code> <small>(sibling)</small></td><td t="docs.loops.foreach.elseSibling"></td></tr>
+        <tr><td><code>else</code> <small>(attribute)</small></td><td t="docs.loops.foreach.elseTpl"></td></tr>
         <tr><td><code>filter</code></td><td t="docs.loops.foreach.filter"></td></tr>
         <tr><td><code>sort</code></td><td t="docs.loops.foreach.sort"></td></tr>
         <tr><td><code>limit</code></td><td t="docs.loops.foreach.limit"></td></tr>
@@ -76,6 +77,22 @@
       <span class="hl-attr">bind</span>=<span class="hl-str">"user.name"</span><span class="hl-tag">&gt;&lt;/li&gt;</span>
   <span class="hl-tag">&lt;li</span> <span class="hl-attr">else</span><span class="hl-tag">&gt;</span>No users found<span class="hl-tag">&lt;/li&gt;</span>
 <span class="hl-tag">&lt;/ul&gt;</span></pre></div>
+  </div>
+
+  <!-- else template reference -->
+  <div class="doc-section">
+    <h2 class="doc-title" t="docs.loops.elseTpl.title"></h2>
+    <p class="doc-text" t="docs.loops.elseTpl.text"></p>
+    <div class="code-block"><pre><span class="hl-tag">&lt;article</span> <span class="hl-attr">foreach</span>=<span class="hl-str">"item in items"</span> <span class="hl-attr">else</span>=<span class="hl-str">"no-items"</span><span class="hl-tag">&gt;</span>
+  <span class="hl-tag">&lt;h2</span> <span class="hl-attr">bind</span>=<span class="hl-str">"item.title"</span><span class="hl-tag">&gt;&lt;/h2&gt;</span>
+<span class="hl-tag">&lt;/article&gt;</span>
+
+<span class="hl-tag">&lt;template</span> <span class="hl-attr">id</span>=<span class="hl-str">"no-items"</span><span class="hl-tag">&gt;</span>
+  <span class="hl-tag">&lt;p&gt;</span>No items found.<span class="hl-tag">&lt;/p&gt;</span>
+<span class="hl-tag">&lt;/template&gt;</span></pre></div>
+    <div class="callout">
+      <p t="docs.loops.elseTpl.callout"></p>
+    </div>
   </div>
 
   <!-- aliases -->


### PR DESCRIPTION
## Summary
- Add `elseTpl` section to `loops.tpl` with code example and callout note
- Split else attribute row into sibling and attribute variants in attributes table
- Add i18n keys across all 5 locales (en, pt, es, fr, it): `elseSibling`, `elseTpl`, `elseTpl.title/text/callout`
- Update cheatsheet else description

## Test plan
- [ ] `npm start` — verify loops docs page renders correctly at localhost:3000
- [ ] Check all 5 locale variants render without missing keys