### PR TITLE
docs: purge sibling-else remnants, document null/undefined elseTpl semantics (NOJS-135)

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -903,7 +903,7 @@ Use the `template` attribute to reference a `<template>` element by ID:
 | `template` | ID of the `<template>` element to clone for each item (optional — when omitted, inline children are the template) |
 | `index` | Variable name for the index (default: `$index`) |
 | `key` | Unique key expression for DOM diffing |
-| `else` | Template ID rendered when array is empty (e.g. `else="noItemsTpl"` or `else="#noItems"`) |
+| `else` | Template ID rendered when the array is empty or null/undefined/non-array (e.g. `else="noItemsTpl"` or `else="#noItems"`) |
 | `filter` | Expression to filter items (like `Array.filter`) |
 | `sort` | Property path to sort by (prefix with `-` for descending) |
 | `limit` | Maximum number of items to render |
@@ -5105,7 +5105,7 @@ Complete reference of every No.JS directive.
 | `sort` | `sort="item.name"` | Sort property |
 | `limit` | `limit="10"` | Max items |
 | `offset` | `offset="5"` | Skip items |
-| `else` | `else="noItemsTpl"` | Template ID rendered when array is empty |
+| `else` | `else="noItemsTpl"` | Template ID rendered when the array is empty or null/undefined |
 
 > **Breaking change (v1.15):** The sibling `else` pattern for loops (`<p else>No items</p>` after a loop element) has been removed. Use `else="templateId"` on the loop element itself to reference a `<template>` for the empty state.
 

--- a/docs/locales/en/docs.json
+++ b/docs/locales/en/docs.json
@@ -136,7 +136,8 @@
         "filter": "Filter expression",
         "sort": "Sort property (name only, not prefixed with item variable)",
         "limit": "Max items",
-        "offset": "Skip items"
+        "offset": "Skip items",
+        "else": "Template rendered when the array is empty or null/undefined"
       },
       "events": {
         "title": "Events",
@@ -498,11 +499,11 @@
         "limit": "Maximum number of items to render",
         "offset": "Number of items to skip",
         "template": "External template ID (optional — children become template if omitted)",
-        "elseTpl": "Template ID rendered when array is empty (e.g. else=\"noItemsTpl\")"
+        "elseTpl": "Template ID rendered when the array is empty or null/undefined (e.g. else=\"noItemsTpl\")"
       },
       "fullExample": {
         "title": "Full Example with All Attributes",
-        "text": "A complete example showing foreach with filtering, sorting, pagination, and a sibling else for the empty-state fallback."
+        "text": "A complete example showing foreach with filtering, sorting, pagination, and an else template for the empty-state fallback."
       },
       "aliases": {
         "title": "Aliases: each and for",
@@ -542,8 +543,8 @@
       },
       "elseTpl": {
         "title": "Else with Template Reference",
-        "text": "Instead of a sibling else element, you can place else=\"templateId\" directly on the loop element. When the array is empty, the referenced template content replaces the loop output.",
-        "callout": "The else attribute on the loop element only activates for empty arrays ([]). For null or undefined sources, the loop simply renders nothing.",
+        "text": "Place else=\"templateId\" directly on the loop element. When the list is empty ([]) or null/undefined, the referenced template content replaces the loop output.",
+        "callout": "The else attribute on the loop element activates for empty arrays ([]) and also for null, undefined, or non-array sources — e.g. API state before the first fetch resolves.",
         "breaking": "Breaking change (v1.15): the sibling else pattern for loops has been removed. Use else=\"templateId\" on the loop element instead."
       }
     },

--- a/docs/locales/es/docs.json
+++ b/docs/locales/es/docs.json
@@ -136,7 +136,8 @@
         "filter": "Expresión de filtro",
         "sort": "Propiedad para ordenar (solo el nombre, sin prefijo de variable de elemento)",
         "limit": "Máximo de elementos",
-        "offset": "Omitir elementos"
+        "offset": "Omitir elementos",
+        "else": "Template renderizado cuando el array está vacío o es null/undefined"
       },
       "events": {
         "title": "Eventos",
@@ -498,11 +499,11 @@
         "offset": "Número de elementos a omitir",
         "preview": "Vista previa",
         "template": "ID de plantilla externa (opcional — los hijos se convierten en la plantilla si se omite)",
-        "elseTpl": "ID de template renderizado cuando el array está vacío (ej: else=\"noItemsTpl\")"
+        "elseTpl": "ID de template renderizado cuando el array está vacío o es null/undefined (ej: else=\"noItemsTpl\")"
       },
       "fullExample": {
         "title": "Ejemplo completo con todos los atributos",
-        "text": "Un ejemplo completo mostrando foreach con filtrado, ordenación, paginación y un else hermano para el fallback de estado vacío."
+        "text": "Un ejemplo completo mostrando foreach con filtrado, ordenación, paginación y un template else para el fallback de estado vacío."
       },
       "aliases": {
         "title": "Aliases: each y for",
@@ -542,8 +543,8 @@
       },
       "elseTpl": {
         "title": "Else con Referencia de Template",
-        "text": "En lugar de un elemento else hermano, puedes colocar else=\"templateId\" directamente en el elemento del loop. Cuando el array está vacío, el contenido del template referenciado reemplaza la salida del loop.",
-        "callout": "El atributo else en el elemento del loop solo se activa para arrays vacíos ([]). Para fuentes null o undefined, el loop simplemente no renderiza nada.",
+        "text": "Coloca else=\"templateId\" directamente en el elemento del loop. Cuando la lista está vacía ([]) o es null/undefined, el contenido del template referenciado reemplaza la salida del loop.",
+        "callout": "El atributo else en el elemento del loop se activa para arrays vacíos ([]) y también para fuentes null, undefined o que no son arrays — por ejemplo, el estado de la API antes del primer fetch.",
         "breaking": "Breaking change (v1.15): el patrón de else hermano para loops ha sido eliminado. Usa else=\"templateId\" en el propio elemento del loop."
       }
     },

--- a/docs/locales/fr/docs.json
+++ b/docs/locales/fr/docs.json
@@ -136,7 +136,8 @@
         "filter": "Expression de filtrage",
         "sort": "Propriété de tri (nom seul, sans préfixe de variable d'élément)",
         "limit": "Nombre maximum d'éléments",
-        "offset": "Éléments à ignorer"
+        "offset": "Éléments à ignorer",
+        "else": "Template rendu quand le tableau est vide ou null/undefined"
       },
       "events": {
         "title": "Événements",
@@ -498,11 +499,11 @@
         "offset": "Nombre d'éléments à ignorer",
         "preview": "Aperçu",
         "template": "ID de template externe (optionnel — les enfants deviennent le template si omis)",
-        "elseTpl": "ID de template rendu quand le tableau est vide (ex : else=\"noItemsTpl\")"
+        "elseTpl": "ID de template rendu quand le tableau est vide ou null/undefined (ex : else=\"noItemsTpl\")"
       },
       "fullExample": {
         "title": "Exemple complet avec tous les attributs",
-        "text": "Un exemple complet montrant foreach avec filtrage, tri, pagination et un else frère pour le secours d'état vide."
+        "text": "Un exemple complet montrant foreach avec filtrage, tri, pagination et un template else pour le secours d'état vide."
       },
       "aliases": {
         "title": "Alias : each et for",
@@ -542,8 +543,8 @@
       },
       "elseTpl": {
         "title": "Else avec Référence de Template",
-        "text": "Au lieu d'un élément else frère, vous pouvez placer else=\"templateId\" directement sur l'élément de boucle. Quand le tableau est vide, le contenu du template référencé remplace la sortie de la boucle.",
-        "callout": "L'attribut else sur l'élément de boucle ne s'active que pour les tableaux vides ([]). Pour les sources null ou undefined, la boucle ne rend simplement rien.",
+        "text": "Placez else=\"templateId\" directement sur l'élément de boucle. Quand la liste est vide ([]) ou null/undefined, le contenu du template référencé remplace la sortie de la boucle.",
+        "callout": "L'attribut else sur l'élément de boucle s'active pour les tableaux vides ([]) et aussi pour les sources null, undefined ou non-array — par exemple l'état de l'API avant la résolution du premier fetch.",
         "breaking": "Breaking change (v1.15) : le pattern else frère pour les boucles a été supprimé. Utilisez else=\"templateId\" sur l'élément de boucle."
       }
     },

--- a/docs/locales/it/docs.json
+++ b/docs/locales/it/docs.json
@@ -136,7 +136,8 @@
         "filter": "Espressione di filtro",
         "sort": "Proprietà di ordinamento (solo nome, senza prefisso della variabile elemento)",
         "limit": "Numero massimo di elementi",
-        "offset": "Salta elementi"
+        "offset": "Salta elementi",
+        "else": "Template renderizzato quando l'array è vuoto o null/undefined"
       },
       "events": {
         "title": "Eventi",
@@ -498,11 +499,11 @@
         "offset": "Numero di elementi da saltare",
         "preview": "Anteprima",
         "template": "ID di template esterno (opzionale — i figli diventano il template se omesso)",
-        "elseTpl": "ID del template renderizzato quando l'array è vuoto (es: else=\"noItemsTpl\")"
+        "elseTpl": "ID del template renderizzato quando l'array è vuoto o null/undefined (es: else=\"noItemsTpl\")"
       },
       "fullExample": {
         "title": "Esempio completo con tutti gli attributi",
-        "text": "Un esempio completo che mostra foreach con filtraggio, ordinamento, paginazione e un else fratello per il fallback di stato vuoto."
+        "text": "Un esempio completo che mostra foreach con filtraggio, ordinamento, paginazione e un template else per il fallback di stato vuoto."
       },
       "aliases": {
         "title": "Alias: each e for",
@@ -542,8 +543,8 @@
       },
       "elseTpl": {
         "title": "Else con Riferimento al Template",
-        "text": "Invece di un elemento else fratello, puoi inserire else=\"templateId\" direttamente sull'elemento del loop. Quando l'array è vuoto, il contenuto del template referenziato sostituisce l'output del loop.",
-        "callout": "L'attributo else sull'elemento del loop si attiva solo per array vuoti ([]). Per sorgenti null o undefined, il loop semplicemente non renderizza nulla.",
+        "text": "Inserisci else=\"templateId\" direttamente sull'elemento del loop. Quando la lista è vuota ([]) o null/undefined, il contenuto del template referenziato sostituisce l'output del loop.",
+        "callout": "L'attributo else sull'elemento del loop si attiva per array vuoti ([]) e anche per sorgenti null, undefined o non-array — ad esempio lo stato dell'API prima che il primo fetch si risolva.",
         "breaking": "Breaking change (v1.15): il pattern else fratello per i loop è stato rimosso. Usa else=\"templateId\" sull'elemento del loop."
       }
     },

--- a/docs/locales/pt/docs.json
+++ b/docs/locales/pt/docs.json
@@ -136,7 +136,8 @@
         "filter": "Expressão de filtro",
         "sort": "Propriedade para ordenação (apenas nome, sem prefixo da variável do item)",
         "limit": "Máximo de itens",
-        "offset": "Pular itens"
+        "offset": "Pular itens",
+        "else": "Template renderizado quando o array está vazio ou é null/undefined"
       },
       "events": {
         "title": "Eventos",
@@ -498,11 +499,11 @@
         "offset": "Número de itens para pular",
         "preview": "Prévia",
         "template": "ID de template externo (opcional — os filhos se tornam o template se omitido)",
-        "elseTpl": "ID de template renderizado quando o array está vazio (ex: else=\"noItemsTpl\")"
+        "elseTpl": "ID de template renderizado quando o array está vazio ou é null/undefined (ex: else=\"noItemsTpl\")"
       },
       "fullExample": {
         "title": "Exemplo completo com todos os atributos",
-        "text": "Um exemplo completo mostrando foreach com filtragem, ordenação, paginação e um else irmão para o fallback de estado vazio."
+        "text": "Um exemplo completo mostrando foreach com filtragem, ordenação, paginação e um template else para o fallback de estado vazio."
       },
       "aliases": {
         "title": "Aliases: each e for",
@@ -542,8 +543,8 @@
       },
       "elseTpl": {
         "title": "Else com Referência de Template",
-        "text": "Em vez de um elemento else irmão, você pode colocar else=\"templateId\" diretamente no elemento do loop. Quando o array está vazio, o conteúdo do template referenciado substitui a saída do loop.",
-        "callout": "O atributo else no elemento do loop só é ativado para arrays vazios ([]). Para fontes null ou undefined, o loop simplesmente não renderiza nada.",
+        "text": "Coloque else=\"templateId\" diretamente no elemento do loop. Quando a lista está vazia ([]) ou é null/undefined, o conteúdo do template referenciado substitui a saída do loop.",
+        "callout": "O atributo else no elemento do loop é ativado para arrays vazios ([]) e também para fontes null, undefined ou que não são arrays — por exemplo, o estado da API antes do primeiro fetch resolver.",
         "breaking": "Breaking change (v1.15): o padrão de else irmão para loops foi removido. Use else=\"templateId\" no próprio elemento do loop."
       }
     },

--- a/docs/md/cheatsheet.md
+++ b/docs/md/cheatsheet.md
@@ -64,8 +64,7 @@ The element with the loop directive IS the repeating template. It is removed fro
 | `foreach` | `foreach="item in items"` | Iterate over arrays (primary directive). The element repeats as siblings. |
 | `each` | `each="item in items"` | Alias for `foreach` |
 | `for` | `for="item in items"` | Alias for `foreach` |
-| `else` (sibling) | `<li else>No items</li>` | Sibling element shown when the loop array is empty/null/undefined |
-| `else` (template) | `else="emptyTpl"` | Reference an external template for the empty state |
+| `else` (template) | `else="noItemsTpl"` | Template rendered when the array is empty or null/undefined |
 | `template` | `template="tplId"` | Template to clone for each item (optional — own children used when omitted) |
 | `index` | `index="i"` | Index variable name |
 | `key` | `key="item.id"` | Unique key for diffing |

--- a/docs/md/conditionals.md
+++ b/docs/md/conditionals.md
@@ -97,7 +97,7 @@ Render one of many templates based on a value.
 
 ## `else` on Loop Elements
 
-Loop directives (`foreach`, `each`, `for`) support `else="templateId"` to reference a `<template>` for empty-state fallback:
+Loop directives (`foreach`, `each`, `for`) support `else="templateId"` to reference a `<template>` for empty-state fallback. The template renders when the list is empty (`[]`) or null/undefined/non-array — e.g. API state before the first fetch:
 
 ```html
 <article foreach="item in items" else="noItems">

--- a/docs/md/data-fetching.md
+++ b/docs/md/data-fetching.md
@@ -89,11 +89,11 @@ Absolute URLs skip base resolution:
      as="users"
      loading="#usersSkeleton"
      error="#usersError"
+     empty="#noUsers"
      refresh="30000"
      cached>
 
   <div each="user in users" template="userCard"></div>
-  <p else>No users found.</p>
 
 </div>
 
@@ -103,6 +103,10 @@ Absolute URLs skip base resolution:
 
 <template id="usersError" var="err">
   <div class="error">Failed to load: <span bind="err.message"></span></div>
+</template>
+
+<template id="noUsers">
+  <p>No users found.</p>
 </template>
 ```
 
@@ -256,9 +260,9 @@ The skeleton is hidden automatically when:
 
 <div get="/api/feed" as="items"
      skeleton="skeleton"
-     loading="#spinnerTpl">
+     loading="#spinnerTpl"
+     empty="#emptyTpl">
   <div each="item in items" template="feedItem"></div>
-  <div else>No feed items</div>
 </div>
 ```
 

--- a/docs/md/error-handling.md
+++ b/docs/md/error-handling.md
@@ -11,7 +11,6 @@ Any HTTP directive (`get`, `post`, `put`, `patch`, `delete`) can declare an erro
 ```html
 <div get="/api/users" as="users" error="#usersError">
   <div each="user in users" template="userCard"></div>
-  <p else>No users found.</p>
 </div>
 
 <template id="usersError" var="err">

--- a/docs/md/examples.md
+++ b/docs/md/examples.md
@@ -84,11 +84,13 @@ automatically — no extra code needed in the route itself.
   <!-- Token is attached automatically via the request interceptor -->
   <div get="/me/dashboard" as="data" loading="#dash-skeleton">
     <h2 bind="'Welcome, ' + data.user.name"></h2>
-    <p each="m in data.metrics">
+    <p each="m in data.metrics" else="noMetrics">
       <span bind="m.label"></span>
       <span bind="m.value | number"></span>
     </p>
-    <p else>No metrics available</p>
+    <template id="noMetrics">
+      <p>No metrics available</p>
+    </template>
   </div>
   <button on:click="$store.auth.user = null; $store.auth.token = null">
     Sign out
@@ -152,13 +154,15 @@ simultaneously — no event bus, no shared component.
 
 <!-- Product list -->
 <div get="/products" as="products">
-  <div each="p in products">
+  <div each="p in products" else="noProducts">
     <span bind="p.name"></span>
     <button on:click="$store.cart.items = [...$store.cart.items, p]">
       Add to cart
     </button>
   </div>
-  <div else>No products available</div>
+  <template id="noProducts">
+    <div>No products available</div>
+  </template>
 </div>
 
 <!-- Cart summary: somewhere else entirely -->
@@ -266,11 +270,13 @@ All five patterns combined into a single production-grade SPA:
   <template route="/dashboard" guard="$store.auth.token" redirect="/login">
     <div get="/me/dashboard" as="data">
       <h1 bind="'Welcome, ' + data.user.name"></h1>
-      <p each="m in data.metrics">
+      <p each="m in data.metrics" else="noMetrics">
         <span bind="m.label"></span>
         <span bind="m.value | number"></span>
       </p>
-      <p else>No metrics available</p>
+      <template id="noMetrics">
+        <p>No metrics available</p>
+      </template>
     </div>
     <button on:click="$store.auth.user = null; $store.auth.token = null">
       Sign out

--- a/docs/md/loops.md
+++ b/docs/md/loops.md
@@ -52,18 +52,22 @@ Use the `template` attribute to reference a `<template>` element by ID. The loop
       filter="item.active"
       sort="item.order"
       limit="10"
-      offset="0">
+      offset="0"
+      else="noItemsTpl">
     <a bind-href="item.link">
       <span bind="idx + 1"></span> - <span bind="item.label"></span>
     </a>
   </li>
-  <li else>No items available</li>
 </ul>
+
+<template id="noItemsTpl">
+  <li>No items available</li>
+</template>
 ```
 
 ### Empty-State Fallback with `else`
 
-When the source array is empty, the loop renders nothing. Place `else="templateId"` on the loop element to reference a `<template>` for the empty state:
+Place `else="templateId"` on the loop element to reference a `<template>` for the empty state. The template renders when the list is empty (`[]`) **or** null/undefined/non-array — e.g. API state before the first fetch resolves:
 
 ```html
 <article foreach="item in items" else="noItems">
@@ -75,7 +79,7 @@ When the source array is empty, the loop renders nothing. Place `else="templateI
 </template>
 ```
 
-When `items` is an empty array (`[]`), the template content replaces the loop output. When items are present, the template is removed and items render normally. Both bare ID (`else="noItems"`) and hash syntax (`else="#noItems"`) are accepted.
+When `items` is an empty array (`[]`), null, undefined, or any non-array value, the template content replaces the loop output. When items are present, the template is removed and items render normally. Both bare ID (`else="noItems"`) and hash syntax (`else="#noItems"`) are accepted.
 
 > **Breaking change (v1.15):** The sibling `else` pattern (`<li else>No items</li>` placed after a loop element) has been removed. Use `else="templateId"` on the loop element itself instead.
 
@@ -84,7 +88,7 @@ When `items` is an empty array (`[]`), the template content replaces the loop ou
 | Attribute | Description |
 |-----------|-------------|
 | `foreach` | `"item in array"` — variable name and source expression |
-| `else` | Template ID rendered when array is empty (e.g. `else="noItemsTpl"`) |
+| `else` | Template ID rendered when the array is empty or null/undefined/non-array (e.g. `else="noItemsTpl"`) |
 | `template` | ID of the `<template>` element to clone for each item (optional — when omitted, the element's own children are the template) |
 | `index` | Variable name for the index (default: `$index`) |
 | `key` | Unique key expression for DOM diffing |
@@ -259,7 +263,7 @@ Loop directives are fully reactive. When the source array changes (push, splice,
 
 ## See Also
 
-- [Conditionals](conditionals.md) — `else` also works as a sibling after loop elements
+- [Conditionals](conditionals.md) — `else="templateId"` on the loop element renders a template for empty lists
 - [Templates](templates.md) — external templates referenced by loops
 - [Animations](animations.md) — `animate-stagger` for list enter/leave effects
 - [Filters & Pipes](filters.md) — `count`, `first`, `last`, `reverse`, `sortBy` filters

--- a/docs/md/templates.md
+++ b/docs/md/templates.md
@@ -164,8 +164,7 @@ Loop directives use the `template` attribute to reference external templates. Th
 
 ```html
 <ul get="/api/users" as="users">
-  <li each="user in users" template="userCard"></li>
-  <li else>No users found</li>
+  <li each="user in users" template="userCard" else="noUsersTpl"></li>
 </ul>
 
 <template id="userCard">
@@ -174,15 +173,19 @@ Loop directives use the `template` attribute to reference external templates. Th
     <p bind="user.email"></p>
   </div>
 </template>
+
+<template id="noUsersTpl">
+  <li>No users found</li>
+</template>
 ```
 
-The sibling `else` element shows when the array is empty. You can also point `else` at a template ID: `else="emptyTpl"`.
+The `else="templateId"` attribute on the loop element references a `<template>` rendered when the array is empty (`[]`) or null/undefined/non-array — e.g. before the fetch resolves.
 
 ---
 
 ## See Also
 
-- [Loops](loops.md) — self-repeating elements and sibling `else` for empty lists
+- [Loops](loops.md) — self-repeating elements and `else="templateId"` for empty lists
 - [Routing](routing.md) — route templates and file-based routing
 - [Data Fetching](data-fetching.md) — `loading`, `error`, `success` templates
 

--- a/docs/templates/docs/cheatsheet.tpl
+++ b/docs/templates/docs/cheatsheet.tpl
@@ -97,7 +97,7 @@
         <tr><td><code>sort</code></td><td><code>sort="name"</code></td><td t="docs.cheatsheet.loops.sort"></td></tr>
         <tr><td><code>limit</code></td><td><code>limit="10"</code></td><td t="docs.cheatsheet.loops.limit"></td></tr>
         <tr><td><code>offset</code></td><td><code>offset="5"</code></td><td t="docs.cheatsheet.loops.offset"></td></tr>
-        <tr><td><code>else</code> <small>(sibling)</small></td><td><code>&lt;li else&gt;No items&lt;/li&gt;</code></td><td t="docs.cheatsheet.loops.else"></td></tr>
+        <tr><td><code>else</code></td><td><code>else="noItemsTpl"</code></td><td t="docs.cheatsheet.loops.else"></td></tr>
       </tbody>
     </table>
   </div>


### PR DESCRIPTION
## Summary

Finishes Genesis task **NOJS-135** on top of the sibling-else removal branch (NOJS-125).

### Stale sibling-else references removed
- `docs/md/loops.md`, `docs/md/templates.md`, `docs/md/cheatsheet.md`, `docs/md/conditionals.md` — sibling-else examples rewritten to the `else="templateId"` pattern (only v1.15 breaking-change callouts still mention the old pattern, intentionally)
- `docs/templates/docs/cheatsheet.tpl` — sibling-else row replaced with an elseTpl row (`else="noItemsTpl"`); the `docs.cheatsheet.loops.else` i18n key re-added to all 5 locales

### New null/undefined semantics (from NOJS-134)
The else template now renders when the list is empty (`[]`) **or** null/undefined/non-array — e.g. API state before the first fetch resolves. Updated everywhere elseTpl is described:
- `docs/md/loops.md` empty-state section, `docs/md/conditionals.md` else-on-loops section
- `docs/llms-full.txt` — both `else` attribute rows
- `docs/locales/{en,es,fr,it,pt}/docs.json` — `elseTpl` description, section text, and callout flipped to new semantics

### Verification
- All 5 locale JSON files parse; 35/35 touched keys present in every locale (EN structure parity)
- `grep -rni sibling docs/` → only breaking-change callouts and legit "clones inserted as siblings" phrasing remain
- Version label kept at **v1.15** per user decision

🤖 Generated with [Claude Code](https://claude.com/claude-code)