### PR TITLE
chore(changelog): move v1.15 epic entries to Unreleased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased](https://github.com/ErickXavier/no-js/compare/v1.14.0...HEAD)
+
+### Added
+
+- Unit tests for the loop `else="templateId"` pattern, the conditionals guard, and null/undefined early-return behavior ([73b36b3](https://github.com/ErickXavier/no-js/commit/73b36b3))
+- E2E tests for loop else patterns across `foreach`/`each`/`for` variants ([b841446](https://github.com/ErickXavier/no-js/commit/b841446))
+- QA regression tests for the else-template hardening fixes ([f67ad0a](https://github.com/ErickXavier/no-js/commit/f67ad0a))
+
+### Changed
+
+- Docs: documented the inline `else="templateId"` pattern on loop elements across markdown docs and HTML templates with i18n keys for all 5 locales ([d25c1c8](https://github.com/ErickXavier/no-js/commit/d25c1c8), [d7d7334](https://github.com/ErickXavier/no-js/commit/d7d7334))
+- Docs: purged all stale sibling-else teaching from markdown docs, `cheatsheet.tpl`, `llms-full.txt`, and all 5 locales; documented the new empty-or-null/undefined else-template semantics ([e8dd849](https://github.com/ErickXavier/no-js/commit/e8dd849))
+
+### Fixed
+
+- Conditionals: guard `else` directive from firing on loop elements that use `else="templateId"` for empty-state rendering — the conditional handler now skips elements with `foreach`, `each`, or `for` attributes ([b24b6e9](https://github.com/ErickXavier/no-js/commit/b24b6e9))
+- Loops: same-ref fast path no longer swallows updates while the else template is showing ([f67ad0a](https://github.com/ErickXavier/no-js/commit/f67ad0a))
+- Loops: a missing else-template ID now clears stale clones and warns once instead of failing silently ([f67ad0a](https://github.com/ErickXavier/no-js/commit/f67ad0a))
+- Loops: the else template is no longer re-cloned on every update while the list stays empty — preserves input state inside the empty-state template ([f67ad0a](https://github.com/ErickXavier/no-js/commit/f67ad0a))
+- Conditionals: `<label for="..." else>` is correctly treated as a conditional else, not a loop element — loop detection now uses the shared `_isLoopElement` predicate ([f67ad0a](https://github.com/ErickXavier/no-js/commit/f67ad0a))
+- Conditionals: one-time warning for an orphan `else` with no preceding `if`/`else-if` ([f67ad0a](https://github.com/ErickXavier/no-js/commit/f67ad0a))
+
+### Breaking Changes
+
+- **Sibling else for loops removed**: the `<p else>No items</p>` pattern (placing an element with `else` after a loop element) is no longer supported. Use `else="templateId"` on the loop element itself to reference a `<template>` for the empty state ([4e20448](https://github.com/ErickXavier/no-js/commit/4e20448))
+- **Loops: null/undefined/non-array lists now render the else template** — previously they rendered nothing; non-array values are now normalized to the empty path so the `else="templateId"` template shows ([f67ad0a](https://github.com/ErickXavier/no-js/commit/f67ad0a))
+
 ## [1.14.0](https://github.com/ErickXavier/no-js/compare/v1.13.3...v1.14.0) — 2026-06-09
 
 ### Added
@@ -32,11 +59,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - First-fetch sentinel registers `_onDispose` — fixes leak on element removal before pagination ([b32fb35](https://github.com/ErickXavier/no-js/commit/b32fb35))
 - `_removeInlineError()` helper added for proper error wrapper cleanup ([b32fb35](https://github.com/ErickXavier/no-js/commit/b32fb35))
 - `fetch.js`: expose response headers via `meta` before `_REPLACE` early return ([b32fb35](https://github.com/ErickXavier/no-js/commit/b32fb35))
-- Conditionals: guard `else` directive from firing on loop elements that use `else="templateId"` for empty-state rendering — the conditional handler now skips elements with `foreach`, `each`, or `for` attributes ([b24b6e9](https://github.com/ErickXavier/no-js/commit/b24b6e9))
-
-### Breaking Changes
-
-- **Sibling else for loops removed**: the `<p else>No items</p>` pattern (placing an element with `else` after a loop element) is no longer supported. Use `else="templateId"` on the loop element itself to reference a `<template>` for the empty state
 
 ## [1.13.3] - 2026-06-05
 


### PR DESCRIPTION
## Summary

`CHANGELOG.md` logged part of the v1.15 (NOJS-125) epic under the already-released `[1.14.0] — 2026-06-09` section, but the `v1.14.0` tag (7eaa675) does not contain that work — it merged to `main` afterwards via PR #137 (bf0eb41).

### Moved out of [1.14.0] into a new [Unreleased] section
- **Fixed**: conditionals guard — `else` directive no longer fires on loop elements using `else="templateId"` (b24b6e9)
- **Breaking Changes**: sibling else for loops removed (now attributed to 4e20448)

### Added to [Unreleased] (rest of the NOJS-125 epic, attributed per `git log v1.14.0..main`)
- **Breaking**: null/undefined/non-array lists now render the else template (f67ad0a)
- **Fixed** (PR #138 squash, f67ad0a): same-ref fast-path guard, missing else-template ID clears stale clones + warns once, no re-cloning of the else template while list stays empty, `_isLoopElement` predicate (`<label for>` fix), orphan-else one-time warning
- **Changed**: else-template docs (d25c1c8, d7d7334) and sibling-else purge + null/undefined semantics docs (e8dd849, PR #139 squash)
- **Added**: unit (73b36b3), E2E (b841446), and QA regression (f67ad0a) test coverage for else-template patterns

No version bump, no `dist/` changes — changelog-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)