### PR TITLE
fix(docs): correct 12+ doc inaccuracies across docs/md/

### DIFF
--- a/docs/md/actions-refs.md
+++ b/docs/md/actions-refs.md
@@ -101,10 +101,11 @@ Rapid clicks automatically **abort** the previous in-flight request before start
 
 ### Events
 
-`call` emits lifecycle events on the document:
+`call` emits events on the NoJS event bus (listen with `NoJS.on(...)`):
 
 - **`fetch:success`** — `{ url, data }` on successful response
 - **`fetch:error`** — `{ url, error }` on failure
+- **`fetch:end`** — `{ url }` when the request completes (success or failure)
 
 ### Request Lifecycle
 

--- a/docs/md/cheatsheet.md
+++ b/docs/md/cheatsheet.md
@@ -23,6 +23,13 @@ Complete reference of every No.JS directive.
 | `skeleton` | `skeleton="cardSkel"` | Show/hide a placeholder element during loading |
 | `retry` | `retry="3"` | Number of retry attempts on failure |
 | `retry-delay` | `retry-delay="1000"` | Delay between retries in ms |
+| `get-trigger` | `get-trigger="scroll"` | Pagination trigger: `"scroll"` (infinite), `"button"` (load more), or `"visible"` |
+| `get-trigger-label` | `get-trigger-label="Show more"` | Label for the auto-generated load-more button (default `"Load More"`) |
+| `get-insert` | `get-insert="append"` | How new pages are inserted: `"append"` or `"prepend"` (default replaces content) |
+| `get-page` | `get-page="1"` | Enable offset-based pagination starting at the given page number |
+| `get-cursor` | `get-cursor` | Enable cursor-based pagination |
+| `get-cursor-field` | `get-cursor-field="next"` | JSON field name containing the next cursor value |
+| `get-threshold` | `get-threshold="300px"` | `rootMargin` for the IntersectionObserver (default `"200px"` for scroll, `"0px"` for visible) |
 
 ## State
 
@@ -85,7 +92,7 @@ The element with the loop directive IS the repeating template. It is removed fro
 | `on:unmounted` | `on:unmounted="cleanup()"` | Lifecycle: unmounted |
 | `on:init` | `on:init="setup()"` | Lifecycle: first processed |
 | `on:updated` | `on:updated="refresh()"` | Lifecycle: DOM mutation observed |
-| `on:error` | `on:error="log($event)"` | Lifecycle: error in subtree |
+| `on:error` | `on:error="log($error)"` | Lifecycle: error in subtree |
 
 ## Styling
 
@@ -98,6 +105,8 @@ The element with the loop directive IS the repeating template. It is removed fro
 | `style-map` | `style-map="{ ... }"` | Style from object |
 
 ## Forms
+
+> **Note:** Form validation requires the [`@erickxavier/nojs-elements`](https://www.npmjs.com/package/@erickxavier/nojs-elements) plugin. Core includes only a stub that disables submission with a console warning.
 
 | Directive | Example | Description |
 |-----------|---------|-------------|
@@ -118,7 +127,7 @@ The element with the loop directive IS the repeating template. It is removed fro
 | `route-view="name"` | `route-view="sidebar"` | Named route outlet |
 | `route-view[src]` | `route-view src="./pages/"` | File-based routing outlet |
 | `route-index` | `route-index="overview"` | Filename for root `/` (default `"index"`) |
-| `ext` | `ext=".html"` | File extension (default `".tpl"`, fallback `".html"`) |
+| `ext` | `ext=".html"` | File extension for file-based routing (default `".tpl"`) |
 | `i18n-ns` | `i18n-ns` | Auto-derive i18n namespace from route filename |
 | `outlet` | `outlet="sidebar"` | Target a named outlet from a route template |
 | `route-active` | `route-active="cls"` | Active link class |
@@ -145,6 +154,8 @@ The element with the loop directive IS the repeating template. It is removed fro
 | `transition` | `transition="fade"` | CSS transition |
 
 ## Drag and Drop
+
+> **Note:** Drag and Drop requires the [`@erickxavier/nojs-elements`](https://www.npmjs.com/package/@erickxavier/nojs-elements) plugin. Core includes only stubs that log a console warning.
 
 | Directive | Example | Description |
 |-----------|---------|-------------|

--- a/docs/md/configuration.md
+++ b/docs/md/configuration.md
@@ -36,7 +36,10 @@
       base: '/',
       scrollBehavior: 'top',  // 'top' | 'preserve' | 'smooth'
       templates: 'pages',       // Default base path for file-based routing (default: 'pages')
-      ext: '.tpl'              // Default file extension for file-based routing (fallback: '.html')
+      ext: '.tpl',             // Default file extension for file-based routing (default: '.tpl')
+      suppressHashWarning: false, // Suppress hash-in-history-mode console warning
+      focusBehavior: 'none',     // Focus management after navigation: 'none' | (future options)
+      viewTransition: true       // Enable View Transition API for route changes (default: true)
     },
     // Note: Anchor links (href="#id") are automatically
     // intercepted in both modes — they scroll to the target
@@ -49,7 +52,8 @@
       detectBrowser: true,
       loadPath: '/locales/{locale}.json',  // Load from external JSON (default: null)
       ns: ['common'],           // Namespaces to preload (default: [])
-      cache: true               // Cache fetched locale files (default: true)
+      cache: true,              // Cache fetched locale files (default: true)
+      persist: false             // Persist selected locale to localStorage (default: false)
     },
 
     // Debugging
@@ -57,10 +61,15 @@
     devtools: true,            // Enables browser devtools panel
 
     // Security
-    sanitize: true,            // Sanitize bind-html
+    sanitize: true,                       // Sanitize bind-html (default: true)
+    dangerouslyDisableSanitize: false,    // Bypass ALL sanitization (not recommended)
 
     // Performance
     exprCacheSize: 500,        // Max entries in the expression/statement LRU caches
+    maxEventListeners: 100,    // Max listeners per event on the NoJS event bus (default: 100)
+
+    // App identity
+    appId: '',                 // Application identifier (exposed via devtools)
   });
 </script>
 ```
@@ -70,6 +79,8 @@
 **Type:** `boolean` | **Default:** `false`
 
 Enables the No.JS browser devtools integration. When `true`, framework state, directive processing, and route navigation are exposed via `window.__NOJS_DEVTOOLS__` for debugging.
+
+> **Security:** Devtools activation is restricted to **localhost environments only** (`localhost`, `127.0.0.1`, `[::1]`, `*.localhost`). Setting `devtools: true` on a production hostname is silently ignored with a console warning.
 
 ---
 
@@ -139,7 +150,9 @@ NoJS.config({
 });
 ```
 
-When `sanitizeHtml` is set to a function, the built-in sanitizer is bypassed entirely and the provided function is used for all `bind-html` content. Set `sanitize: false` to disable sanitization entirely (not recommended — see [Security](#security)).
+When `sanitizeHtml` is set to a function, the built-in sanitizer is bypassed entirely and the provided function is used for all `bind-html` content. Set `dangerouslyDisableSanitize: true` to disable sanitization entirely (not recommended — see [Security](#security)).
+
+> **Note:** The `sanitize`, `dangerouslyDisableSanitize`, and `sanitizeHtml` config keys are **locked after `init()`** completes. Calling `NoJS.config()` after initialization will not change these values — this prevents plugins or late-running scripts from weakening the security posture.
 
 The built-in sanitizer blocks the following tags by default: `script`, `style`, `iframe`, `object`, `embed`, `base`, `form`, `meta`, `link`, `noscript`. It also strips `on*` event handler attributes and `javascript:`/`vbscript:` scheme attributes on any element, and `data:` URIs on URL attributes (`href`, `src`, `action`) unless they are safe image types.
 
@@ -235,6 +248,55 @@ NoJS.config({ exprCacheSize: 100 });
 ```
 
 Non-positive or non-numeric values are ignored and the default of 500 is used.
+
+---
+
+### `maxEventListeners`
+
+**Type:** `number` | **Default:** `100`
+
+Maximum number of listener functions allowed per event name on the NoJS event bus (`NoJS.on()`). When the limit is reached, a `MaxListenersExceeded` warning is logged and the new listener is still registered. Increase this if your application legitimately uses many listeners for the same event (e.g. a plugin-heavy setup).
+
+---
+
+### `appId`
+
+**Type:** `string` | **Default:** `""`
+
+An optional application identifier. Exposed via the devtools panel for distinguishing between multiple NoJS instances or environments.
+
+---
+
+### `i18n.persist`
+
+**Type:** `boolean` | **Default:** `false`
+
+When `true`, the currently selected locale is persisted to `localStorage`. On the next page load, the persisted locale is restored automatically — useful for remembering a user's language preference across sessions.
+
+```js
+NoJS.i18n({ persist: true });
+```
+
+---
+
+## Event Bus Events
+
+The NoJS event bus (`NoJS.on()`) emits the following framework events. Use `NoJS.on(event, callback)` to subscribe; the returned function unsubscribes the listener.
+
+| Event | Payload | When |
+|-------|---------|------|
+| `fetch:success` | `{ url, data }` | An HTTP directive (`get`/`post`/etc.) received a successful response |
+| `fetch:error` | `{ url, error }` | An HTTP directive failed (network error or non-ok status) |
+| `fetch:end` | `{ url }` | An HTTP request completed (success or failure) — useful for spinners or progress bars |
+| `plugins:ready` | _(none)_ | All registered plugins have been initialized during `NoJS.init()` |
+
+```js
+// Example: global loading indicator
+let activeRequests = 0;
+NoJS.on('fetch:success', () => { activeRequests--; updateSpinner(); });
+NoJS.on('fetch:error', () => { activeRequests--; updateSpinner(); });
+NoJS.on('fetch:end', () => { /* always fires, regardless of outcome */ });
+```
 
 ---
 

--- a/docs/md/data-binding.md
+++ b/docs/md/data-binding.md
@@ -94,9 +94,12 @@ For form inputs, `model` creates automatic two-way data binding:
 </div>
 ```
 
-### Multi-Select
+### Multi-Select (Planned)
+
+> **Warning:** Multi-select `model` binding is **not yet implemented**. The current `model` directive uses `el.value` for `<select>` elements and does not read `selectedOptions` or handle the `multiple` attribute. An array-backed model will write back a single string value, not an array of selected values. This feature is planned for a future release.
 
 ```html
+<!-- NOT YET FUNCTIONAL — shown for reference only -->
 <div state="{ selected: [] }">
   <select model="selected" multiple>
     <option value="a">Option A</option>

--- a/docs/md/data-fetching.md
+++ b/docs/md/data-fetching.md
@@ -292,6 +292,89 @@ hidden. These attributes are not injected automatically in the current release.
 
 ---
 
+## Pagination & Infinite Scroll
+
+No.JS supports built-in pagination for `get` directives. New pages of data can be appended or prepended to the existing content without replacing it.
+
+### Pagination Attributes
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `get-trigger` | `string` | How the next page is requested: `"scroll"` (IntersectionObserver-based infinite scroll), `"button"` (auto-generated "Load More" button), or `"visible"` (fetch when element enters viewport) |
+| `get-trigger-label` | `string` | Label text for the load-more button (default: `"Load More"`) |
+| `get-insert` | `string` | How new data is inserted: `"append"` (after existing items) or `"prepend"` (before existing items). **Required** for `scroll` and `button` triggers — without it, content is replaced |
+| `get-page` | `number` | Enable offset-based pagination. Sets the initial page number (default: `1`). Auto-increments on each fetch. Use `{page}` in the URL to interpolate |
+| `get-cursor` | _(boolean)_ | Enable cursor-based pagination. The cursor value is extracted from each response and used in the next request via `{cursor}` in the URL |
+| `get-cursor-field` | `string` | JSON field name to extract the next cursor from (e.g. `"nextCursor"`). When omitted, defaults to auto-detection |
+| `get-threshold` | `string` | `rootMargin` for the IntersectionObserver. Default: `"200px"` for `scroll`, `"0px"` for `visible` |
+
+> **Note:** `get-cursor` and `get-page` are mutually exclusive. If both are set, cursor-based pagination takes precedence with a console warning.
+
+### Offset-Based Pagination
+
+```html
+<div get="/api/posts?page={page}&limit=10"
+     as="posts"
+     get-trigger="scroll"
+     get-insert="append"
+     get-page="1"
+     get-threshold="300px">
+  <div each="post in posts" key="post.id">
+    <h3 bind="post.title"></h3>
+  </div>
+</div>
+```
+
+The `page` context variable starts at `1` and auto-increments after each successful fetch. When the server returns an empty array, pagination stops automatically.
+
+### Cursor-Based Pagination
+
+```html
+<div get="/api/feed?cursor={cursor}&limit=20"
+     as="items"
+     get-trigger="scroll"
+     get-insert="append"
+     get-cursor
+     get-cursor-field="nextCursor">
+  <div each="item in items" key="item.id">
+    <p bind="item.content"></p>
+  </div>
+</div>
+```
+
+The cursor starts as an empty string on the first request. After each response, the value of the field specified by `get-cursor-field` is extracted and used for the next request.
+
+### Load More Button
+
+```html
+<div get="/api/comments?page={page}"
+     as="comments"
+     get-trigger="button"
+     get-trigger-label="Show older comments"
+     get-insert="append"
+     get-page="1">
+  <div each="comment in comments" key="comment.id">
+    <p bind="comment.text"></p>
+  </div>
+</div>
+```
+
+The button is auto-generated and inserted after the content. It is automatically removed when the end of data is reached or while a fetch is in progress.
+
+### `fetch:end` Event
+
+The `fetch:end` event fires on the NoJS event bus after every HTTP request completes, regardless of success or failure. This is useful for dismissing global loading indicators:
+
+```js
+NoJS.on('fetch:end', ({ url }) => {
+  console.log('Request finished:', url);
+});
+```
+
+See [Configuration → Event Bus Events](configuration.md#event-bus-events) for all available bus events.
+
+---
+
 ## Interceptors
 
 Interceptors hook into the fetch pipeline to modify requests, inspect responses, or short-circuit the entire flow. They support async functions and have a 5-second timeout per interceptor.

--- a/docs/md/error-handling.md
+++ b/docs/md/error-handling.md
@@ -41,7 +41,12 @@ Retries use linear delay (not exponential backoff). The `loading` template remai
 
 ## `error-boundary` — Catch Errors in a Subtree
 
-Wrap a section of your page with `error-boundary` to catch any error that occurs within it — including expression evaluation errors, failed HTTP requests, and runtime exceptions:
+Wrap a section of your page with `error-boundary` to catch errors that occur within its subtree. The boundary intercepts two kinds of errors:
+
+1. **Expression evaluation errors** — dispatched as `nojs:error` CustomEvents that bubble up from handler expressions (e.g. a `bind` or `on:click` expression throws).
+2. **Window-level errors** — uncaught JS errors and resource load failures (e.g. an `<img>` 404) that originate from elements inside the boundary.
+
+> **Note:** `error-boundary` does **not** catch failed HTTP requests made by `get`/`post`/`put`/`patch`/`delete` directives. Use the `error` attribute on the fetch element for per-request error handling, or `NoJS.on('fetch:error', ...)` for global HTTP error handling.
 
 ```html
 <div error-boundary="#errorFallback">
@@ -58,7 +63,7 @@ Wrap a section of your page with `error-boundary` to catch any error that occurs
 </template>
 ```
 
-When an error is caught, the boundary dispatches a `nojs:error` CustomEvent on the boundary element with the error details in `event.detail`.
+When an error is caught, the boundary replaces its children with the fallback template. The `nojs:error` CustomEvent carries the error details in `event.detail`.
 
 ---
 

--- a/docs/md/events.md
+++ b/docs/md/events.md
@@ -52,7 +52,7 @@ Bind any DOM event directly in HTML:
 
 <!-- Key modifiers -->
 <input on:keydown.enter="submit()"
-       on:keydown.ctrl.s="save()"
+       on:keydown.ctrl.enter="save()"
        on:keydown.shift.delete="deleteAll()" />
 
 <!-- Combine modifiers -->
@@ -77,6 +77,8 @@ Bind any DOM event directly in HTML:
 | `.alt` | Alt key held |
 | `.shift` | Shift key held |
 | `.meta` | Meta/Command key held |
+
+> **Note:** Only the modifiers listed above are supported. Single-letter key modifiers (e.g. `.s`, `.a`) are **not** recognized and will be silently ignored. Combine `.ctrl`, `.alt`, `.shift`, or `.meta` with named keys like `.enter`, `.escape`, `.space`, etc.
 
 ---
 

--- a/docs/md/head-management.md
+++ b/docs/md/head-management.md
@@ -144,11 +144,17 @@ wins. Keep one directive per head element per page.
 
 ### Cleanup on unmount
 
-Head elements (`<title>`, `<meta name="description">`, etc.) injected by
-these directives are **not removed** if the host `<div hidden>` is later
-removed from the DOM (e.g. via an `if=` directive). The head element remains
-with its last value. This is by design for the common case (always-present
-host element), but worth noting for conditional page-metadata patterns.
+The `page-description`, `page-canonical`, and `page-jsonld` directives
+register disposal hooks that **remove** the `<head>` elements they created
+when the host `<div hidden>` is removed from the DOM (e.g. via an `if=`
+directive or SPA route change). This prevents stale metadata from persisting
+across route transitions. Only elements created by the directive are removed
+— hand-written elements already present in `<head>` are left untouched.
+
+`page-title` is the exception: it sets `document.title` directly and does
+**not** reset the title on disposal, since the browser always requires a
+title value. The last value persists until another directive or route
+overwrites it.
 
 ### `page-jsonld` template capture
 

--- a/docs/md/routing.md
+++ b/docs/md/routing.md
@@ -181,7 +181,7 @@ Instead of declaring each route template manually, point your `route-view` outle
 |-----------|---------|-------------|
 | `src` | `"pages"` | Base folder for template resolution (per-outlet override; config: `router.templates`) |
 | `route-index` | `"index"` | Filename for the root route `/` |
-| `ext` | `".tpl"` | File extension appended to route segments (fallback: `".html"`) |
+| `ext` | `".tpl"` | File extension appended to route segments |
 | `i18n-ns` | — | When present, auto-derives i18n namespace from filename |
 
 > **Config default:** The default `router.templates` is `"pages"`, so file-based routing works out of the box — just add `route-view` to your outlet. Override with `NoJS.config({ router: { templates: 'views' } })` or per-outlet via `src="./custom/"`.


### PR DESCRIPTION
## Summary

- **C16** cheatsheet.md: `on:error` handler receives `$error`, not `$event` (verified in `src/directives/events.js:54`)
- **C9** cheatsheet.md: add "requires @erickxavier/nojs-elements" callout to Forms (validate) and Drag-and-Drop table sections
- **C13** cheatsheet.md, configuration.md, routing.md: remove nonexistent `.html` extension fallback from `ext` descriptions (no fallback logic in `src/router.js`)
- **C7** error-handling.md: narrow `error-boundary` claim — catches expression errors + window errors, NOT failed HTTP requests (verified in `src/directives/error-boundary.js`)
- **C8** head-management.md: update cleanup section — `page-description`, `page-canonical`, `page-jsonld` ARE removed on dispose; only `page-title` persists (verified in `src/directives/head.js`)
- **C6** events.md: change `on:keydown.ctrl.s` to `on:keydown.ctrl.enter` — letter-key modifiers not supported; add note (verified in `src/directives/events.js` keyMods array)
- **C11** configuration.md: replace `sanitize: false` with `dangerouslyDisableSanitize: true`; add locked-after-init note (verified in `src/index.js:145,168`)
- **C3** data-binding.md: mark multi-select `model` as Planned/not-yet-implemented (verified in `src/directives/binding.js` — only `el.value` for SELECT, no `selectedOptions` handling)
- **C15** data-fetching.md: add Pagination & Infinite Scroll section documenting `get-trigger`, `get-insert`, `get-page`, `get-cursor`, `get-cursor-field`, `get-threshold` (verified in `src/directives/http.js:85-115`); add matching cheatsheet rows; document `fetch:end` event
- **C17** actions-refs.md: reword "emits lifecycle events on the document" to "emits events on the NoJS event bus"; add `fetch:end`
- **C18** configuration.md: document undocumented config options (`i18n.persist`, `maxEventListeners`, `appId`, router `suppressHashWarning`/`focusBehavior`/`viewTransition`); add devtools localhost-only note; add sanitize keys locked-after-init note; add Event Bus Events section documenting `fetch:end` and `plugins:ready`

## Test plan

- [ ] Verify all claims by cross-referencing each fix against the source code cited
- [ ] Confirm no markdown rendering issues in the docs site
- [ ] Docs-only — no build required