### PR TITLE
docs: expand API coverage, fix changelog URLs, add migration guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,7 +79,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `_removeInlineError()` helper added for proper error wrapper cleanup ([b32fb35](https://github.com/ErickXavier/no-js/commit/b32fb35))
 - `fetch.js`: expose response headers via `meta` before `_REPLACE` early return ([b32fb35](https://github.com/ErickXavier/no-js/commit/b32fb35))
 
-## [1.13.3] - 2026-06-05
+## [1.13.3](https://github.com/ErickXavier/no-js/compare/v1.13.1...v1.13.3) — 2026-06-05
 
 ### Fixed
 
@@ -94,7 +94,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Reintegrated core hardening (engine, directives, subsystems) from security review onto current main.
 
-## [1.13.2] - 2026-06-02
+## [1.13.2](https://github.com/ErickXavier/no-js/compare/v1.13.1...v1.13.2) — 2026-06-02
 
 ### Fixed
 
@@ -110,13 +110,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Related modules: `globals.js`, `filters.js`, `i18n.js`, `devtools.js`, and the `binding`, `styling`, `state`, `events`, `refs`, and `head` directives.
 - The prior DnD/validation extraction to `@erickxavier/nojs-elements` remains intact — no behavior reverted.
 
-## [1.13.1] - 2026-06-01
+## [1.13.1](https://github.com/ErickXavier/no-js/compare/v1.13.0...v1.13.1) — 2026-06-01
 
 ### Changed
 
 - Ecosystem version-sync release — no functional changes to Core. Bumped to stay lockstep with the rest of the NoJS ecosystem, companion to the NoJS-LSP plugin-metadata polish.
 
-## [1.13.0] - 2026-05-27
+## [1.13.0](https://github.com/ErickXavier/no-js/compare/v1.12.0...v1.13.0) — 2026-05-27
 
 ### Changed
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -39,6 +39,72 @@ No.JS replaces JavaScript framework boilerplate with declarative HTML attributes
 - [Error Handling](https://no-js.dev/#/error-handling): Per-element `error` templates, `error-boundary` for subtree isolation, global error handler via `NoJS.on('error', fn)`
 - [Configuration](https://no-js.dev/#/configuration): `NoJS.config()` for global settings (baseApiUrl, headers, timeout, retries), request/response interceptors, CSRF token support
 
+## Public API
+
+Methods and properties on the `NoJS` object (`import NoJS from '@erickxavier/no-js'` or `window.NoJS` via CDN):
+
+### Configuration
+
+- `NoJS.config(opts?: object): void` — Merge global settings. Keys: `baseApiUrl` (string), `headers` (object), `timeout` (number, ms), `retries` (number), `cache` (object), `templates` (object), `router` (object), `i18n` (object), `stores` (object), `exprCacheSize` (number, default 500), `dangerouslyDisableSanitize` (boolean), `maxEventListeners` (number), `debug` (boolean), `appId` (string), `csrf` (object). Security-critical keys (`sanitize`, `dangerouslyDisableSanitize`, `sanitizeHtml`) are locked after `init()`.
+- `NoJS.baseApiUrl: string` — Get or set the base API URL for fetch directives.
+
+### Lifecycle
+
+- `NoJS.init(root?: HTMLElement): Promise<void>` — Initialize the framework. Loads i18n locales, processes template includes, loads remote templates (phase 1 blocking, phase 2 background), activates the router if a `[route-view]` element exists, processes the DOM tree, and runs plugin `init` hooks. Called automatically by the CDN build; manual for ESM/CJS. Returns a Promise that resolves when first paint is complete.
+- `NoJS.dispose(): Promise<void>` — Full teardown. Awaits any in-flight `init()`, disposes plugins in reverse installation order (with 3s timeout each), clears globals, interceptors, router, and devtools. Resets config lock.
+
+### Plugin System
+
+- `NoJS.use(plugin: object | function, options?: object): void` — Register a plugin. Plugin must have `{ name: string, install: function }` or be a named function. The `install(NoJS, options)` callback runs immediately. If `init()` has already completed and the plugin has an `init` method, it is called. Options: `{ trusted: true }` grants access to sensitive HTTP headers.
+- `NoJS.global(name: string, value: any): void` — Register a reactive global accessible as `$name` in expressions. Validates identifier format, blocks reserved names and prototype pollution vectors, sanitizes object values, and wraps in a reactive context. Notifies all store watchers on registration.
+- `NoJS.internals: object` — Frozen object exposing semi-private APIs for trusted plugins: `execStatement`, `cloneTemplate`, `disposeChildren`, `disposeTree`, `warn`, `validators`, `removeCoreDirective`, `onDispose`.
+
+### Directives, Filters, and Validators
+
+- `NoJS.directive(name: string, handler: object): void` — Register a custom directive. Handler: `{ priority: number, init(el: HTMLElement, attrName: string, value: string): void }`. Core directives are frozen after `init()` — plugins can add new ones but not override built-ins.
+- `NoJS.filter(name: string, fn: function): void` — Register a custom filter for pipe syntax (`value | filterName`). Built-in filter names cannot be overridden. Throws `TypeError` if name or fn is invalid.
+- `NoJS.validator(name: string, fn: function): void` — Register a custom form validation rule. Built-in validator names (`required`, `email`, `url`, `min`, `max`, `minlength`, `maxlength`, `pattern`, `match`, `number`, `integer`, `alpha`, `alphanumeric`) cannot be overridden. Throws `TypeError` if name or fn is invalid.
+
+### Internationalization
+
+- `NoJS.i18n(opts: object): void` — Configure i18n. Options: `loadPath` (string, e.g. `/locales/{locale}.json`), `defaultLocale` (string), `fallbackLocale` (string), `persist` (boolean, saves to localStorage), `detectBrowser` (boolean), `ns` (array of namespace strings), `cache` (boolean), `locales` (object mapping locale codes to metadata).
+- `NoJS.locale: string` — Get or set the active locale. Setting triggers re-fetch of all loaded namespaces for the new locale.
+
+### Event Bus
+
+- `NoJS.on(event: string, fn: function): function` — Subscribe to a global event. Returns an unsubscribe function. Warns on listener count exceeding `maxEventListeners` (configurable, helps detect memory leaks).
+
+### HTTP Interceptors
+
+- `NoJS.interceptor(type: 'request' | 'response', fn: function): void` — Register a request or response interceptor. Supports async functions. When called inside a plugin's `install()`, the interceptor is tracked to that plugin. Request interceptors can return `NoJS.CANCEL` (abort), `NoJS.RESPOND` (short-circuit with mock), or `NoJS.REPLACE` (swap response data).
+
+### State
+
+- `NoJS.store: object` — Access the global store object. Stores are created via `NoJS.config({ stores: { name: data } })` or the `store` directive.
+- `NoJS.notify(): void` — Trigger UI update after external JavaScript mutations to store data. Notifies all store watchers.
+
+### Routing
+
+- `NoJS.router: object | null` — Access the router instance (created when a `[route-view]` element exists). Methods: `push(path)`, `replace(path)`, `back()`, `forward()`. `null` if no route-view outlet is in the DOM.
+
+### Sentinel Symbols
+
+- `NoJS.CANCEL: Symbol` — Return from a request interceptor to abort the request.
+- `NoJS.RESPOND: Symbol` — Return from a request interceptor to short-circuit with a mock response.
+- `NoJS.REPLACE: Symbol` — Return from a response interceptor to replace the response data.
+
+### Utility Functions (for custom directives)
+
+- `NoJS.createContext(data: object): Proxy` — Create a new reactive context (Proxy-backed) from a plain object.
+- `NoJS.evaluate(expr: string, context: object): any` — Evaluate a No.JS expression against a reactive context. CSP-safe, no eval.
+- `NoJS.resolve(expr: string, context: object): any` — Resolve a dotted property path against a context.
+- `NoJS.findContext(el: HTMLElement): object | null` — Walk up the DOM to find the nearest reactive context attached to an ancestor element.
+- `NoJS.processTree(root: HTMLElement): void` — Walk a DOM subtree and execute all matching directives by priority.
+
+### Metadata
+
+- `NoJS.version: string` — The framework version string (e.g. `"1.14.1"`).
+
 ## Reference
 
 - [Directive Cheatsheet](https://no-js.dev/#/cheatsheet): Every directive with syntax, attributes, and usage at a glance

--- a/docs/migration-v1.13.md
+++ b/docs/migration-v1.13.md
@@ -1,0 +1,127 @@
+# Migrating to No.JS v1.13.0
+
+## Overview
+
+No.JS v1.13.0 (2026-05-27) moved **Drag and Drop** and **Form Validation** from Core into the [`@erickxavier/nojs-elements`](https://elements.no-js.dev) plugin package. This is a **breaking change** for any project that uses `drag`, `drop`, `drag-list`, `drag-multiple`, or `validate` directives.
+
+Core now ships lightweight deprecation stubs for these directives. If your HTML uses them without loading Elements, the stubs emit a console warning explaining the migration but do not provide the functionality.
+
+## What was removed from Core
+
+| Directive | File removed | Lines | Replacement |
+|-----------|-------------|-------|-------------|
+| `drag`, `drop`, `drag-list`, `drag-multiple` | `src/directives/dnd.js` | 1,162 | `@erickxavier/nojs-elements` |
+| `validate` | `src/directives/validation.js` | 552 | `@erickxavier/nojs-elements` |
+
+The associated unit tests and E2E tests were also migrated to the Elements repository.
+
+## What was added
+
+- `NoJS.internals` — a frozen getter exposing semi-private APIs (`execStatement`, `cloneTemplate`, `disposeChildren`, `disposeTree`, `warn`, `validators`, `removeCoreDirective`, `onDispose`) that Elements uses to register its full directive implementations.
+- `_removeCoreDirective(name)` — allows the Elements plugin to replace Core's deprecation stubs with the real implementations at install time.
+- `error-boundary` was extracted to its own file (`src/directives/error-boundary.js`) but **stays in Core** — no migration needed.
+
+## Migration steps
+
+### 1. Install NoJS Elements
+
+```bash
+npm install @erickxavier/nojs-elements
+```
+
+Or via CDN:
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/@erickxavier/nojs-elements/dist/iife/nojs-elements.js"></script>
+```
+
+### 2. Load Elements after Core
+
+**CDN (IIFE):**
+
+```html
+<!-- Core -->
+<script src="https://cdn.no-js.dev/"></script>
+<!-- Elements plugin — must come after Core -->
+<script src="https://cdn.jsdelivr.net/npm/@erickxavier/nojs-elements/dist/iife/nojs-elements.js"></script>
+```
+
+The Elements IIFE auto-registers itself via `NoJS.use()`.
+
+**ESM / npm:**
+
+```js
+import NoJS from '@erickxavier/no-js';
+import NoJSElements from '@erickxavier/nojs-elements';
+
+NoJS.use(NoJSElements);
+NoJS.init();
+```
+
+### 3. Update your HTML (usually no changes needed)
+
+The directive names (`drag`, `drop`, `drag-list`, `drag-multiple`, `validate`) remain identical. Once Elements is loaded, the stubs are replaced with the full implementations. Your existing HTML templates should work without modification.
+
+### 4. Update custom validators
+
+If you registered custom validators via `NoJS.validator()`, this still works the same way. The validator registry is shared between Core and Elements.
+
+## Before and after
+
+### Before (v1.12.x and earlier)
+
+```html
+<script src="https://cdn.no-js.dev/"></script>
+
+<form validate>
+  <input model="email" validate="required,email">
+  <button type="submit">Submit</button>
+</form>
+
+<div drag="item">Drag me</div>
+<div drop="handleDrop">Drop here</div>
+```
+
+### After (v1.13.0+)
+
+```html
+<script src="https://cdn.no-js.dev/"></script>
+<script src="https://cdn.jsdelivr.net/npm/@erickxavier/nojs-elements/dist/iife/nojs-elements.js"></script>
+
+<!-- HTML is identical — no changes needed -->
+<form validate>
+  <input model="email" validate="required,email">
+  <button type="submit">Submit</button>
+</form>
+
+<div drag="item">Drag me</div>
+<div drop="handleDrop">Drop here</div>
+```
+
+The only change is adding the Elements script tag.
+
+## How to detect if you are affected
+
+If after upgrading to v1.13.0+ you see console warnings like:
+
+```
+[NoJS] "validate" has moved to @erickxavier/nojs-elements. Install it to restore functionality.
+[NoJS] "drag" has moved to @erickxavier/nojs-elements. Install it to restore functionality.
+```
+
+Then you need to add the Elements plugin as described above.
+
+## Projects that do NOT use DnD or validation
+
+If your project does not use `drag`, `drop`, `drag-list`, `drag-multiple`, or `validate` directives, **no migration is needed**. The Core framework is otherwise backward-compatible with v1.12.x.
+
+## FAQ
+
+**Q: Why were these features moved out of Core?**
+A: To keep Core lightweight and focused on the reactive engine. DnD and validation are substantial features (1,700+ lines combined) that not every project needs. Moving them to Elements allows users to opt in only when needed, and enables independent release cycles for these features.
+
+**Q: Does Elements add any other features?**
+A: Yes. NoJS Elements also provides UI components like tooltips, popovers, modals, dropdowns, toasts, tabs, trees, steppers, skeletons, split panes, and sortable tables. See [elements.no-js.dev](https://elements.no-js.dev) for the full list.
+
+**Q: Can I use Elements without Core?**
+A: No. Elements is a plugin that requires Core (`@erickxavier/no-js`) to be loaded first.


### PR DESCRIPTION
## Summary

- **llms.txt**: Expanded from ~5 guide links to full documentation of all 20+ public API methods and properties on the `NoJS` object, organized by category (Configuration, Lifecycle, Plugin System, Directives/Filters/Validators, i18n, Event Bus, Interceptors, State, Routing, Sentinel Symbols, Utilities, Metadata), each with parameter types, return values, and descriptions
- **CHANGELOG.md**: Fixed broken compare URLs for v1.13.0 through v1.13.3 — entries used reference-style links `[1.13.x]` with no link definitions at the bottom; converted to inline URLs matching the format of all other entries
- **migration-v1.13.md**: New migration guide documenting the v1.13.0 breaking change that moved DnD (`drag`, `drop`, `drag-list`, `drag-multiple`) and validation (`validate`) from Core to `@erickxavier/nojs-elements`, with before/after code examples and step-by-step instructions

## Out of scope (separate change needed)

The workspace-root `CLAUDE.md` (`/Users/erick/_projects/_personal/NoJS/CLAUDE.md`) has factual errors about CLI being Rust/cargo — these were fixed locally but the file is outside this git repo and cannot be included in this PR.

## Test plan

- [x] `node build.js` passes
- [x] `npm test` passes (27 suites, 1764 tests)
- [x] Verify CHANGELOG compare URLs resolve correctly on GitHub
- [x] Verify llms.txt API documentation matches `src/index.js` public API