### PR TITLE
perf: add robots.txt and optimize Core Web Vitals

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -19,10 +19,25 @@
   <meta name="twitter:title" content="No.JS - HTML-First Reactive Framework">
   <meta name="twitter:description" content="Build dynamic, reactive web applications using nothing but HTML attributes. No build step. No virtual DOM. No transpiler.">
   <meta name="twitter:image" content="https://no-js.dev/thumbnail.png">
+  <!-- Preconnect to external origins (DNS + TLS handshake in parallel) -->
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <link rel="preconnect" href="https://cdn.no-js.dev" crossorigin>
+  <link rel="preconnect" href="https://www.googletagmanager.com">
+  <link rel="dns-prefetch" href="https://fonts.googleapis.com">
+  <link rel="dns-prefetch" href="https://fonts.gstatic.com">
+  <link rel="dns-prefetch" href="https://cdn.no-js.dev">
+
+  <!-- Preload critical CSS (highest priority, avoids late discovery) -->
+  <link rel="preload" href="assets/style.css" as="style">
   <link rel="stylesheet" href="assets/style.css">
+
+  <!-- Preload NoJS framework script (starts fetch early, deferred execution) -->
+  <link rel="preload" href="https://cdn.no-js.dev/" as="script" crossorigin>
+
+  <!-- Google Fonts — non-render-blocking (swap to screen media on load) -->
+  <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" media="print" onload="this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet"></noscript>
 
   <!-- ─── Boot Loader (critical, inline so it paints before style.css) ── -->
   <style>

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://no-js.dev/sitemap.xml


### PR DESCRIPTION
## Summary

- **NOJS-171**: Add `docs/robots.txt` with standard crawl-friendly directives and sitemap reference for the Core docs site
- **NOJS-172**: Optimize Largest Contentful Paint (LCP) on the docs site by eliminating render-blocking resources

### LCP Optimizations Applied

| Optimization | Impact |
|---|---|
| Preconnect to `cdn.no-js.dev`, `googletagmanager.com` | Saves ~100-200ms DNS+TLS per origin |
| DNS-prefetch fallbacks for all external origins | Broader browser support |
| Preload `assets/style.css` as critical CSS | Earlier discovery, higher fetch priority |
| Preload NoJS CDN script | Starts download during HTML parse |
| **Defer Google Fonts** via `media="print" onload` pattern | **Biggest win** -- eliminates render-blocking 3-font stylesheet |
| Noscript fallback for Google Fonts | Graceful degradation |

### Target

LCP improvement from ~5.4s to <=2.5s on GitHub Pages (the Google Fonts stylesheet was the primary render-blocking bottleneck).

### Follow-ups needed (other repos)

- [ ] Add `docs/robots.txt` to NoJS-Elements (`elements.no-js.dev`)
- [ ] Add `docs/robots.txt` to NoJS-LSP (`lsp.no-js.dev`)
- [ ] Apply same LCP optimizations to Elements and LSP docs sites

## Test plan

- [x] `node build.js` passes
- [x] `npm test` passes (27 suites, 1764 tests)
- [ ] Verify docs site loads correctly with deferred fonts (fonts should appear after initial paint, no FOUT issues due to `display=swap` in the Fonts API URL)
- [ ] Run Lighthouse on deployed page to confirm LCP improvement
- [ ] Verify `robots.txt` is accessible at `https://no-js.dev/robots.txt`