### PR TITLE
chore(docs): update org references in llms.txt files

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -20,7 +20,7 @@ No.JS replaces JavaScript framework boilerplate with declarative HTML attributes
 ## Interaction
 
 - [Events](#events) — `on:*`, modifiers, lifecycle hooks, `$event`, `$el`
-- [Forms & Validation](#forms--validation) — `validate`, `$form`, custom validators (requires `@erickxavier/nojs-elements` plugin since v1.13.0)
+- [Forms & Validation](#forms--validation) — `validate`, `$form`, custom validators (requires `@no-js-dev/nojs-elements` plugin since v1.13.0)
 - [Actions & Refs](#actions--refs) — `call`, `trigger`, `ref`, `$refs`
 
 ## Presentation
@@ -37,7 +37,7 @@ No.JS replaces JavaScript framework boilerplate with declarative HTML attributes
 - [Custom Directives](#custom-directives) — Extend No.JS with your own directives
 - [Error Handling](#error-handling) — Per-element errors, boundaries, global handler via `NoJS.on('error', fn)`
 - [Configuration](#configuration--security) — Global settings, interceptors, CSRF, security
-- [Drag and Drop](#drag-and-drop) — `drag`, `drop`, sortable lists, multi-select (requires `@erickxavier/nojs-elements` plugin since v1.13.0)
+- [Drag and Drop](#drag-and-drop) — `drag`, `drop`, sortable lists, multi-select (requires `@no-js-dev/nojs-elements` plugin since v1.13.0)
 - [Plugins](#plugins) — Plugin system with lifecycle hooks, interceptors, globals
 
 ## Reference
@@ -65,18 +65,18 @@ Download `dist/iife/no.js` and include it with a `<script>` tag.
 ### npm / ESM
 
 ```bash
-npm install @erickxavier/no-js
+npm install @no-js-dev/nojs
 ```
 
 ```javascript
-import NoJS from '@erickxavier/no-js';
+import NoJS from '@no-js-dev/nojs';
 NoJS.init();
 ```
 
 Or with CommonJS:
 
 ```javascript
-const NoJS = require('@erickxavier/no-js');
+const NoJS = require('@no-js-dev/nojs');
 NoJS.init();
 ```
 
@@ -1813,11 +1813,11 @@ The `trigger` directive emits a custom event from the element, typically used fo
 
 # Forms & Validation
 
-> **Moved to NoJS Elements** — As of v1.13.0, the `validate` directive and form validation rules are part of the `@erickxavier/nojs-elements` plugin.
+> **Moved to NoJS Elements** — As of v1.13.0, the `validate` directive and form validation rules are part of the `@no-js-dev/nojs-elements` plugin.
 >
-> See the [NoJS Elements documentation](https://github.com/ErickXavier/nojs-elements) for the full reference.
+> See the [NoJS Elements documentation](https://github.com/no-js-dev/nojs-elements) for the full reference.
 >
-> **Migration:** Install `@erickxavier/nojs-elements` and add `NoJS.use(NoJSElements)` before `NoJS.init()`.
+> **Migration:** Install `@no-js-dev/nojs-elements` and add `NoJS.use(NoJSElements)` before `NoJS.init()`.
 >
 > **Note:** Declarative form submission (`post`, `put`, etc.) remains in core — only the `validate` directive moved.
 
@@ -4522,11 +4522,11 @@ See [Plugins →](plugins.md) for the full API reference, plugin lifecycle, secu
 
 # Drag & Drop
 
-> **Moved to NoJS Elements** — As of v1.13.0, the drag-and-drop directives (`drag`, `drop`, `drag-list`, `drag-multiple`) are part of the `@erickxavier/nojs-elements` plugin.
+> **Moved to NoJS Elements** — As of v1.13.0, the drag-and-drop directives (`drag`, `drop`, `drag-list`, `drag-multiple`) are part of the `@no-js-dev/nojs-elements` plugin.
 >
-> See the [NoJS Elements documentation](https://github.com/ErickXavier/nojs-elements) for the full reference.
+> See the [NoJS Elements documentation](https://github.com/no-js-dev/nojs-elements) for the full reference.
 >
-> **Migration:** Install `@erickxavier/nojs-elements` and add `NoJS.use(NoJSElements)` before `NoJS.init()`.
+> **Migration:** Install `@no-js-dev/nojs-elements` and add `NoJS.use(NoJSElements)` before `NoJS.init()`.
 
 ## Quick Start
 
@@ -5175,7 +5175,7 @@ The element with the loop directive IS the repeating template. It is removed fro
 
 ## Forms
 
-> **Note:** Form validation requires the [`@erickxavier/nojs-elements`](https://www.npmjs.com/package/@erickxavier/nojs-elements) plugin. Core includes only a stub that disables submission with a console warning.
+> **Note:** Form validation requires the [`@no-js-dev/nojs-elements`](https://www.npmjs.com/package/@no-js-dev/nojs-elements) plugin. Core includes only a stub that disables submission with a console warning.
 
 | Directive | Example | Description |
 |-----------|---------|-------------|
@@ -5224,7 +5224,7 @@ The element with the loop directive IS the repeating template. It is removed fro
 
 ## Drag and Drop
 
-> **Note:** Drag and Drop requires the [`@erickxavier/nojs-elements`](https://www.npmjs.com/package/@erickxavier/nojs-elements) plugin. Core includes only stubs that log a console warning.
+> **Note:** Drag and Drop requires the [`@no-js-dev/nojs-elements`](https://www.npmjs.com/package/@no-js-dev/nojs-elements) plugin. Core includes only stubs that log a console warning.
 
 | Directive | Example | Description |
 |-----------|---------|-------------|

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -20,7 +20,7 @@ No.JS replaces JavaScript framework boilerplate with declarative HTML attributes
 ## Interaction
 
 - [Events](https://no-js.dev/#/events): `on:click`, `on:keydown.enter`, `on:submit.prevent`; modifiers (`.stop`, `.once`, `.debounce.300`); lifecycle hooks (`on:mounted`, `on:init`, `on:updated`, `on:error`, `on:unmounted`); `$event` and `$el` references
-- [Forms & Validation](https://no-js.dev/#/forms-validation): `validate` attribute with built-in rules (`required`, `email`, `min`, `max`, `pattern`); `$form` context for form state; custom validators via `NoJS.validator()` (requires `@erickxavier/nojs-elements` plugin since v1.13.0)
+- [Forms & Validation](https://no-js.dev/#/forms-validation): `validate` attribute with built-in rules (`required`, `email`, `min`, `max`, `pattern`); `$form` context for form state; custom validators via `NoJS.validator()` (requires `@no-js-dev/nojs-elements` plugin since v1.13.0)
 - [Actions & Refs](https://no-js.dev/#/actions-refs): `call` (trigger HTTP from any element), `trigger` (dispatch custom events), `ref` (name an element), `$refs` (access named elements)
 
 ## Presentation
@@ -34,14 +34,14 @@ No.JS replaces JavaScript framework boilerplate with declarative HTML attributes
 - [Routing](https://no-js.dev/#/routing): SPA navigation with `route="/path/:param"`, `route-view` outlet, route guards, nested routes, View Transition API (slide, fade, scale presets), file-based routing, query params, hash navigation, redirects, 404 handling
 - [Head Management](https://no-js.dev/#/head-management): Per-route `page-title`, `page-description`, `page-canonical`, `page-jsonld` attributes on `<template route>`
 - [Internationalization](https://no-js.dev/#/i18n): `t="key"` directive, pluralization, locale switching, async locale loading, fallback chains, interpolation
-- [Drag and Drop](https://no-js.dev/#/drag-and-drop): `drag` source, `drop` zone, `drag-list` for sortable reordering, multi-select, custom placeholders, event handlers (requires `@erickxavier/nojs-elements` plugin since v1.13.0)
+- [Drag and Drop](https://no-js.dev/#/drag-and-drop): `drag` source, `drop` zone, `drag-list` for sortable reordering, multi-select, custom placeholders, event handlers (requires `@no-js-dev/nojs-elements` plugin since v1.13.0)
 - [Custom Directives](https://no-js.dev/#/custom-directives): Extend the framework via `NoJS.directive(name, { priority, init(el, name, value) })` with full access to the reactive context
 - [Error Handling](https://no-js.dev/#/error-handling): Per-element `error` templates, `error-boundary` for subtree isolation, global error handler via `NoJS.on('error', fn)`
 - [Configuration](https://no-js.dev/#/configuration): `NoJS.config()` for global settings (baseApiUrl, headers, timeout, retries), request/response interceptors, CSRF token support
 
 ## Public API
 
-Methods and properties on the `NoJS` object (`import NoJS from '@erickxavier/no-js'` or `window.NoJS` via CDN):
+Methods and properties on the `NoJS` object (`import NoJS from '@no-js-dev/nojs'` or `window.NoJS` via CDN):
 
 ### Configuration
 
@@ -116,7 +116,7 @@ Methods and properties on the `NoJS` object (`import NoJS from '@erickxavier/no-
 
 - [NoJS Elements](https://elements.no-js.dev): UI element plugins — drag-and-drop, form validation, tooltips, popovers, modals, dropdowns, toasts, tabs, trees, steppers, skeletons, split panes, sortable tables
 - [NoJS LSP](https://lsp.no-js.dev): VS Code language server extension — completions for 43+ directives, real-time diagnostics, hover docs, go-to-definition, semantic highlighting, code actions, and 23 built-in snippets
-- [NoJS Skill](https://github.com/ErickXavier/nojs-skill): Claude Code AI skill for No.JS development
-- [npm](https://www.npmjs.com/package/@erickxavier/no-js): Install via npm
-- [GitHub](https://github.com/ErickXavier/no-js): Source code, issues, and contributions
+- [NoJS Skill](https://github.com/no-js-dev/nojs-skill): Claude Code AI skill for No.JS development
+- [npm](https://www.npmjs.com/package/@no-js-dev/nojs): Install via npm
+- [GitHub](https://github.com/no-js-dev/nojs): Source code, issues, and contributions
 - [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=exs.nojs-lsp): Install the NoJS LSP extension directly


### PR DESCRIPTION
Update remaining @erickxavier/no-js references to @no-js-dev/nojs in LLM context files (llms.txt, llms-full.txt). Missed during NOJS-84 migration because .txt files were not in the grep include list.