### PR TITLE
fix(test): make fromNow filter test timezone-safe

### DIFF
--- a/__tests__/filters.test.js
+++ b/__tests__/filters.test.js
@@ -402,20 +402,31 @@ describe('filters.js — sortBy without key', () => {
 });
 
 describe('filters.js — fromNow future dates', () => {
+  let nowSpy;
+  const FIXED_NOW = new Date('2025-06-15T12:00:00.000Z').getTime();
+
+  beforeEach(() => {
+    nowSpy = jest.spyOn(Date, 'now').mockReturnValue(FIXED_NOW);
+  });
+
+  afterEach(() => {
+    nowSpy.mockRestore();
+  });
+
   test('fromNow in a moment for near-future', () => {
-    const soonDate = new Date(Date.now() + 30 * 1000);
+    const soonDate = new Date(FIXED_NOW + 30 * 1000);
     const result = _filters.fromNow(soonDate.toISOString());
     expect(result).toBe('in a moment');
   });
 
   test('fromNow in Xm for future minutes', () => {
-    const futureMin = new Date(Date.now() + 10 * 60 * 1000);
+    const futureMin = new Date(FIXED_NOW + 10 * 60 * 1000);
     const result = _filters.fromNow(futureMin.toISOString());
     expect(result).toBe('in 10m');
   });
 
   test('fromNow in Xd for future days', () => {
-    const futureDays = new Date(Date.now() + 3 * 86400 * 1000);
+    const futureDays = new Date(FIXED_NOW + 3 * 86400 * 1000);
     const result = _filters.fromNow(futureDays.toISOString());
     expect(result).toBe('in 3d');
   });


### PR DESCRIPTION
## Summary

- The `fromNow future dates` test suite was flaky in CI because `Date.now()` was called once when constructing the future date and again inside `fromNow()`, causing a tiny time drift that made `Math.floor` round down incorrectly (e.g. "in 2d" instead of "in 3d") at UTC day boundaries.
- Fixed by mocking `Date.now()` to a fixed UTC noon timestamp (`2025-06-15T12:00:00Z`) so the diff between date creation and evaluation is exactly zero, eliminating all timezone and boundary sensitivity.

## Test plan

- [x] `npx jest --no-coverage __tests__/filters.test.js` — all 74 filter tests pass
- [x] Full test suite (`npm test`) — 1797 passed, 3 skipped, 0 failures
- [ ] CI should pass consistently regardless of runner timezone or execution time