### PR TITLE
fix(docs): add base href for SPA deep-link refresh

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <base href="/">
   <title>NoJS — Build the Web. No JavaScript.</title>
 
   <!-- SEO Meta Tags -->

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <base href="/">
   <title>NoJS — Build the Web. No JavaScript.</title>
 
   <!-- SEO Meta Tags -->

--- a/docs/playground/engine.js
+++ b/docs/playground/engine.js
@@ -45,10 +45,9 @@
     }, 50);
   }
 
-  // Re-initialize on hashchange (user navigates away and comes back)
-  window.addEventListener('hashchange', function() {
-    if (location.hash.indexOf('#/playground') === 0 || location.hash === '#/playground') {
-      // Small delay to let router load the template
+  // Re-initialize on navigation (user navigates away and comes back)
+  window.addEventListener('popstate', function() {
+    if (location.pathname === '/playground' || location.pathname === '/playground/') {
       setTimeout(function() {
         if (!document.querySelector('.playground-page')) return;
         waitForContext(boot);


### PR DESCRIPTION
Fixes playground (and all routes) breaking on page refresh. Root cause: docs/playground/ directory triggers GitHub Pages trailing-slash redirect, breaking all relative asset paths.